### PR TITLE
IR-183 - Wire AIP validator up to lambda handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ AWS Lambda to validate a [Bagit](https://www.ietf.org/rfc/rfc8493.txt) bag store
 
 - Build the container:
 
-  ```bash
-  docker build -t validator:latest .
-  ```
+```bash
+docker build -t validator:latest .
+```
 
 - Run the default handler for the container:
 
-  ```bash
-  docker run -e WORKSPACE=dev -p 9000:8080 validator:latest
-  ```
+```bash
+docker run --env-file .env -p 9000:8080 validator:latest
+```
 
 - Post to the container:
 
-  ```bash
-  curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
-  ```
+```bash
+curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
+```
 
 - Observe output:
 
@@ -55,6 +55,7 @@ SENTRY_DSN=### If set to a valid Sentry DSN, enables Sentry exception monitoring
 WORKSPACE=### Set to `dev` for local development, this will be set to `stage` and `prod` in those environments by Terraform.
 AWS_ATHENA_DATABASE=### Athena database to query for S3 Inventory data 
 AWS_ATHENA_WORK_GROUP=### Athena workgroup to use for queries
+CHALLENGE_SECRET=### Secret string that is passed as part of lambda invocation payload and checked before running
 ```
 
 ### Optional

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -15,6 +15,7 @@ class Config:
         "SENTRY_DSN",
         "AWS_ATHENA_WORK_GROUP",
         "AWS_ATHENA_DATABASE",
+        "CHALLENGE_SECRET",
     )
     OPTIONAL_ENV_VARS = (
         "AWS_DEFAULT_REGION",
@@ -40,13 +41,6 @@ class Config:
     @property
     def aws_region(self) -> str:
         return self.AWS_DEFAULT_REGION or "us-east-1"
-
-
-def check_verbosity(verbose: bool | str) -> bool:
-    """Determine whether verbose is True or False given a boolean or string value."""
-    if isinstance(verbose, bool):
-        return verbose
-    return verbose.lower() == "true"
 
 
 def configure_logger(

--- a/lambdas/validator.py
+++ b/lambdas/validator.py
@@ -1,7 +1,10 @@
 import json
 import logging
+from dataclasses import dataclass
+from http import HTTPStatus
 
-from lambdas.config import Config, check_verbosity, configure_logger
+from lambdas.aip import AIP
+from lambdas.config import Config, configure_logger
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -9,12 +12,101 @@ logger.setLevel(logging.DEBUG)
 CONFIG = Config()
 
 
-def lambda_handler(event: dict) -> str:
-    """AWS Lambda entrypoint."""
-    CONFIG.check_required_env_vars()
-    verbose = check_verbosity(event.get("verbose", False))
-    configure_logger(logging.getLogger(), verbose=verbose)
+@dataclass
+class InputPayload:
+    aip_s3_uri: str
+    challenge_secret: str
+    verbose: bool = False
 
+
+def lambda_handler(event: dict, _context: dict) -> dict:
+    """AWS Lambda entrypoint.
+
+    This entrypoint handles a direct invocation (e.g. boto3) or an invocation via an HTTP
+    request (e.g. ALB or Function URL).  Once the input payload is parsed, and the
+    challenge secret verified, the AIP class is used to perform validation.
+    """
+    CONFIG.check_required_env_vars()
+
+    # parse payload
+    try:
+        payload = parse_payload(event)
+    except ValueError as exc:
+        logger.error(exc)  # noqa: TRY400
+        return generate_error_response(str(exc), HTTPStatus.BAD_REQUEST)
+
+    configure_logger(logging.getLogger(), verbose=payload.verbose)
     logger.debug(json.dumps(event))
 
-    return "You have successfully called this lambda!"
+    # check challenge secret
+    try:
+        validate_secret(payload.challenge_secret)
+    except RuntimeError as exc:
+        logger.error(exc)  # noqa: TRY400
+        return generate_error_response(str(exc), HTTPStatus.UNAUTHORIZED)
+
+    # validate AIP
+    aip = AIP(payload.aip_s3_uri)
+    try:
+        result = aip.validate()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(exc)  # noqa: TRY400
+        return generate_error_response(str(exc), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    return generate_result_response(result.to_dict())
+
+
+def validate_secret(challenge_secret: str | None) -> None:
+    """Check that secret passed with lambda invocation matches secret env var."""
+    if not challenge_secret or challenge_secret.strip() != CONFIG.CHALLENGE_SECRET:
+        raise RuntimeError("Challenge secret missing or mismatch.")
+
+
+def parse_payload(event: dict) -> InputPayload:
+    """Parse input payload, raising an exception if invalid.
+
+    This lambda will usually be invoked by an HTTP request to an ALB, resulting in an
+    'event' payload as outlined here: https://docs.aws.amazon.com/apigateway/latest/
+    developerguide/http-api-develop-integrations-lambda.html.  This function attempts to
+    identify what format the event is in before parsing.
+    """
+    body = json.loads(event["body"]) if "requestContext" in event else event
+
+    try:
+        return InputPayload(**body)
+    except Exception as exc:
+        message = f"Invalid input payload: {exc}"
+        logger.error(message)  # noqa: TRY400
+        raise ValueError(message) from exc
+
+
+def generate_error_response(
+    error: str,
+    http_status_code: int = HTTPStatus.INTERNAL_SERVER_ERROR,
+) -> dict:
+    """Produce a response object suitable for HTTP responses.
+
+    See more: https://docs.aws.amazon.com/apigateway/latest/developerguide/
+    http-api-develop-integrations-lambda.html
+    """
+    return {
+        "statusCode": http_status_code,
+        "headers": {"Content-Type": "application/json"},
+        "isBase64Encoded": False,
+        "body": json.dumps({"error": error}),
+    }
+
+
+def generate_result_response(response: dict) -> dict:
+    """Produce a response object suitable for HTTP responses.
+
+    See more: https://docs.aws.amazon.com/apigateway/latest/developerguide/
+    http-api-develop-integrations-lambda.html
+    """
+    return {
+        "statusCode": HTTPStatus.OK,
+        "statusDescription": "200 OK",
+        "headers": {"Content-Type": "application/json"},
+        "isBase64Encoded": False,
+        "body": json.dumps(response),
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from lambdas.utils.aws.athena import AthenaClient
 def _test_env(monkeypatch, request):
     monkeypatch.setenv("WORKSPACE", "test")
     monkeypatch.setenv("SENTRY_DSN", "None")
+    monkeypatch.setenv("CHALLENGE_SECRET", "i-am-secret")
 
     # do not set for integration tests
     if not request.node.get_closest_marker("integration"):

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,16 +1,146 @@
+# ruff: noqa: S105, S106
+import json
+from http import HTTPStatus
+from unittest.mock import patch
+
 import pytest
 
 from lambdas import validator
+from lambdas.aip import ValidationResponse
 
 
-def test_lambda_handler_missing_workspace_env_raises_error(monkeypatch):
-    monkeypatch.delenv("WORKSPACE", raising=False)
-    with pytest.raises(
-        OSError,
-        match="Missing required environment variables: WORKSPACE",
-    ):
-        validator.lambda_handler({})
+class TestInitialization:
+    def test_lambda_handler_missing_env_vars_raises_error(self, monkeypatch):
+        monkeypatch.delenv("WORKSPACE", raising=False)
+        with pytest.raises(
+            OSError,
+            match="Missing required environment variables: WORKSPACE",
+        ):
+            validator.lambda_handler({}, {})
 
 
-def test_validator():
-    assert validator.lambda_handler({}) == "You have successfully called this lambda!"
+class TestInputPayload:
+    def test_init_with_valid_data(self):
+        payload = validator.InputPayload(
+            aip_s3_uri="s3://bucket/aip", challenge_secret="mysecret"
+        )
+        assert payload.aip_s3_uri == "s3://bucket/aip"
+        assert payload.challenge_secret == "mysecret"
+        assert payload.verbose is False
+
+    def test_init_with_verbose_true(self):
+        payload = validator.InputPayload(
+            aip_s3_uri="s3://bucket/aip", challenge_secret="mysecret", verbose=True
+        )
+        assert payload.verbose is True
+
+
+class TestParsePayload:
+    def test_parse_payload_from_http_request(self):
+        event = {
+            "requestContext": {},
+            "body": json.dumps(
+                {
+                    "aip_s3_uri": "s3://bucket/aip",
+                    "challenge_secret": "mysecret",
+                    "verbose": True,
+                }
+            ),
+        }
+
+        payload = validator.parse_payload(event)
+        assert payload.aip_s3_uri == "s3://bucket/aip"
+        assert payload.challenge_secret == "mysecret"
+        assert payload.verbose is True
+
+    def test_parse_payload_from_direct_event(self):
+        event = {
+            "aip_s3_uri": "s3://bucket/aip",
+            "challenge_secret": "mysecret",
+            "verbose": False,
+        }
+
+        payload = validator.parse_payload(event)
+        assert payload.aip_s3_uri == "s3://bucket/aip"
+        assert payload.challenge_secret == "mysecret"
+        assert payload.verbose is False
+
+    def test_parse_payload_invalid_raises_value_error(self):
+        event = {"body": json.dumps({"wrong_param": "value"})}
+        with pytest.raises(ValueError, match="Invalid input payload:"):
+            validator.parse_payload(event)
+
+
+class TestValidateSecret:
+    def test_validate_secret_success(self):
+        validator.validate_secret("i-am-secret")
+
+    def test_validate_secret_mismatch(self, monkeypatch):
+        monkeypatch.setenv("CHALLENGE_SECRET", "i-am-different-secret")
+        with pytest.raises(RuntimeError, match="Challenge secret missing or mismatch."):
+            validator.validate_secret("i-am-secret")
+
+
+class TestResponseGeneration:
+    def test_generate_error_response(self):
+        response = validator.generate_error_response(
+            "Test error message", HTTPStatus.BAD_REQUEST
+        )
+        assert response["statusCode"] == HTTPStatus.BAD_REQUEST
+        assert response["headers"] == {"Content-Type": "application/json"}
+        assert response["isBase64Encoded"] is False
+        assert json.loads(response["body"]) == {"error": "Test error message"}
+
+    def test_generate_error_response_default_status(self):
+        response = validator.generate_error_response("Test error message")
+        assert response["statusCode"] == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert json.loads(response["body"]) == {"error": "Test error message"}
+
+    def test_generate_result_response(self):
+        test_data = {"key": "value", "nested": {"data": 123}}
+        response = validator.generate_result_response(test_data)
+        assert response["statusCode"] == HTTPStatus.OK
+        assert response["statusDescription"] == "200 OK"
+        assert response["headers"] == {"Content-Type": "application/json"}
+        assert response["isBase64Encoded"] is False
+        assert json.loads(response["body"]) == test_data
+
+
+class TestLambdaHandler:
+    def test_lambda_handler_success(self):
+        event = {
+            "aip_s3_uri": "s3://bucket/aip",
+            "challenge_secret": "i-am-secret",
+        }
+        mock_result = ValidationResponse(
+            s3_uri="s3://bucket/aip",
+            valid=True,
+            elapsed=1.5,
+            manifest={"data/file1.txt": "abc123"},
+        )
+        with patch("lambdas.validator.AIP") as mock_aip_class:
+            mock_aip_instance = mock_aip_class.return_value
+            mock_aip_instance.validate.return_value = mock_result
+            response = validator.lambda_handler(event, {})
+
+        assert response["statusCode"] == HTTPStatus.OK
+        assert response["statusDescription"] == "200 OK"
+        body = json.loads(response["body"])
+        assert body["valid"] is True
+        assert body["s3_uri"] == "s3://bucket/aip"
+        assert body["manifest"] == {"data/file1.txt": "abc123"}
+
+    def test_lambda_handler_invalid_payload(self):
+        event = {"invalid": "payload"}
+        response = validator.lambda_handler(event, {})
+        assert response["statusCode"] == HTTPStatus.BAD_REQUEST
+        assert "error" in json.loads(response["body"])
+
+    def test_lambda_handler_invalid_secret(self):
+        event = {"aip_s3_uri": "s3://bucket/aip", "challenge_secret": "wrong-secret"}
+        response = validator.lambda_handler(event, {})
+        assert response["statusCode"] == HTTPStatus.UNAUTHORIZED
+        assert (
+            json.loads(response["body"])["error"]
+            == "Challenge secret missing or mismatch."
+        )

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -66,7 +66,7 @@ class TestParsePayload:
         assert payload.verbose is False
 
     def test_parse_payload_invalid_raises_value_error(self):
-        event = {"body": json.dumps({"wrong_param": "value"})}
+        event = {"msg": "in a bottle"}
         with pytest.raises(ValueError, match="Invalid input payload:"):
             validator.parse_payload(event)
 


### PR DESCRIPTION
### Purpose and background context

This PR wires up the AWS lambda handler `validator.lambda_handler` to the `AIP` class that fully encapsulates the validation logic.

For any given lambda invocation, the flow is roughly:
1. parse input payload; often will be from an [HTTP request](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)
2. validate payload contains arguments needed for validation
3. perform a lightweight challenge secret check
4. perform AIP validation
5. return a response

### How can a reviewer manually see the effects of these changes?

Run the lambda locally and invoke via a CURL request.

1- Build a docker image:
```shell
docker build -t validator:latest .
```

2- Set env vars:
```shell
WORKSPACE=dev
SENTRY_DSN=None
VERBOSE_LOGGING=true

AWS_ATHENA_DATABASE=cdps-storage-dev-222053980223-aip-database
AWS_ATHENA_WORK_GROUP=default-222053980223-us-east-1

WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3

CHALLENGE_SECRET=i-am-the-secret

AWS_ACCESS_KEY_ID=...
AWS_SECRET_ACCESS_KEY=...
AWS_SESSION_TOKEN=...
```

3- Run docker image, ensuring to pass a `.env` file with good AWS credentials (pro tip: don't wrap your AWS credentials in double quotes, doesn't appear to work):
```shell
docker run --env-file .env -p 9000:8080 validator:latest
```

4- Make a `curl` request to the lambda, emulating a request coming through the ALB:
```
curl --location 'http://localhost:9000/2015-03-31/functions/function/invocations' \
--header 'Content-Type: application/json' \
--data '{
    "challenge_secret":"i-am-the-secret",
    "aip_s3_uri":"s3://cdps-storage-dev-222053980223-aipstore4b/4b06/4dbd/1492/4ff7/a853/ab28/e9c2/fc74/Level04-preservation-sampleD-4b064dbd-1492-4ff7-a853-ab28e9c2fc74",
    "verbose":true
}'
```

5- Alternatively, make a `curl` command to the deployed Dev1 instance:

```shell
curl --location 'https://hftcsnwr6dl4v2hblpibvhnhwm0ckbkt.lambda-url.us-east-1.on.aws/2015-03-31/functions/function/invocations' \
--header 'Content-Type: application/json' \
--data '{
    "challenge_secret":"pickles",
    "aip_s3_uri":"s3://cdps-storage-dev-222053980223-aipstore4b/4b06/4dbd/1492/4ff7/a853/ab28/e9c2/fc74/Level04-preservation-sampleD-4b064dbd-1492-4ff7-a853-ab28e9c2fc74",
    "verbose":false
}'
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES: Lambda is callable

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IR-183

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes