### PR TITLE
IR 193 - parallelize checksum generation

### DIFF
--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -1,17 +1,22 @@
 import base64
 import binascii
+import concurrent.futures
 import json
 import logging
 import re
 from dataclasses import asdict, dataclass
+from threading import Lock
 from time import perf_counter
 
 import pandas as pd
 
+from lambdas.config import Config
 from lambdas.exceptions import AIPValidationError
 from lambdas.utils.aws import AthenaClient, S3Client
 
 logger = logging.getLogger(__name__)
+
+CONFIG = Config()
 
 
 @dataclass
@@ -72,7 +77,9 @@ class AIP:
             )
         return None
 
-    def validate(self) -> ValidationResponse:
+    def validate(
+        self, num_workers: int = CONFIG.checksum_num_workers
+    ) -> ValidationResponse:
         """Validate that AIP manifest files and checksums match the AIP in S3.
 
         Flow:
@@ -98,7 +105,7 @@ class AIP:
             self.files = self._get_aip_files()
             self._check_aip_files_match_manifest()
             self.s3_inventory = self._get_aip_s3_inventory()
-            self.file_checksums = self._get_aip_file_checksums()
+            self.file_checksums = self._get_aip_file_checksums(num_workers=num_workers)
             self._check_checksums()
 
             return ValidationResponse(
@@ -174,6 +181,7 @@ class AIP:
 
     def _get_aip_s3_inventory(self) -> pd.DataFrame:
         """Query S3 Inventory for list of files."""
+        logger.info("Retrieving S3 Inventory data via Athena")
         with open("lambdas/sql/s3_inventory.sql") as f:
             query_string = f.read()
         inventory_df = self.athena_client.query(
@@ -185,18 +193,22 @@ class AIP:
                 f"S3 Inventory data not found for S3 key: '{self.s3_key}'"
             )
 
-        return inventory_df
+        # index by file key and return
+        return inventory_df.set_index("key")
 
     @staticmethod
     def _decode_base64_sha256(base64_checksum: str | bytes) -> str:
         binary_checksum = base64.b64decode(base64_checksum)
         return binascii.hexlify(binary_checksum).decode("ascii")
 
-    def _get_aip_file_checksums(self) -> dict[str, str]:
+    def _get_aip_file_checksums(
+        self, num_workers: int = CONFIG.checksum_num_workers
+    ) -> dict[str, str]:
         """Retrieve checksums for all files listed in Bagit manifest.
 
         If a SHA256 checksum does not exist, generate one by copying the object onto
-        itself.
+        itself.  This process is performed in parallel via threads by the worker function
+        'process_file_worker' which updates a local dictionary of file-to-checksum.
         """
         if self.manifest_df is None:
             raise ValueError("Bagit manifest data not found")
@@ -204,23 +216,58 @@ class AIP:
             raise ValueError("S3 Inventory data not found")
 
         file_checksums = {}
-        s3_inventory_indexed = self.s3_inventory.set_index("key")
+        file_checksums_lock = Lock()
 
-        for _, row in self.manifest_df.iterrows():
+        def process_file_worker(row: pd.Series) -> None:
             filepath = row.filepath
-            logger.debug(f"Getting checksum for AIP file: {filepath}")
-
             s3_uri = f"{self.s3_uri}/{filepath}"
-            inventory_row = s3_inventory_indexed.loc[f"{self.s3_key}/{filepath}"]
+            inventory_row = self.s3_inventory.loc[  # type: ignore[union-attr]
+                f"{self.s3_key}/{filepath}"
+            ]
 
-            if "SHA256" not in inventory_row["checksum_algorithm"]:
+            # retrieve or generate SHA256
+            if inventory_row["checksum_algorithm"] != "SHA256":
                 base64_checksum = self.s3_client.generate_checksum_for_object(s3_uri)
             else:
                 base64_checksum = self.s3_client.get_checksum_for_object(s3_uri)
 
+            # convert base64 form to ascii
             checksum = self._decode_base64_sha256(base64_checksum)
-            logger.debug(f"Filepath '{filepath}', checksum '{checksum}'")
-            file_checksums[filepath] = checksum
+            logger.debug(f"AIP file: '{filepath}', checksum: '{checksum}'")
+
+            # save file:checksum dictionary
+            with file_checksums_lock:
+                file_checksums[filepath] = checksum
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+            # prepare futures of workers
+            futures = [
+                executor.submit(process_file_worker, row)
+                for _, row in self.manifest_df.iterrows()
+            ]
+
+            total_futures = len(futures)
+            completed = 0
+            progress_threshold = max(1, total_futures // 10)
+            next_threshold = progress_threshold
+
+            # loop through futures and respond as each completes
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                    completed += 1
+                    if completed >= next_threshold or completed == total_futures:
+                        logger.info(
+                            f"Processed {completed}/{total_futures} "
+                            f"files ({(completed / total_futures) * 100:.1f}%)"
+                        )
+                        next_threshold = min(
+                            total_futures, completed + progress_threshold
+                        )
+
+                except Exception:
+                    logger.exception("Error getting checksum for file")
+                    raise
 
         return file_checksums
 

--- a/lambdas/sql/s3_inventory.sql
+++ b/lambdas/sql/s3_inventory.sql
@@ -1,32 +1,25 @@
 with cdps_aip_inventory as (
     select * from "aip1b-data"
-    union select * from "aip2b-data"
-    union select * from "aip3b-data"
-    union select * from "aip4b-data"
-    union select * from "aip5b-data"
+    union all select * from "aip2b-data"
+    union all select * from "aip3b-data"
+    union all select * from "aip4b-data"
+    union all select * from "aip5b-data"
 ),
-aip_files as (
-    select * from cdps_aip_inventory
+date_ordered_files as (
+    select
+        *,
+        row_number() over (partition by key order by last_modified_date desc) as rn
+    from cdps_aip_inventory
     where key like %(s3_key_prefix)s
-    -- the following utilizes the hive 'dt' partition, limiting data scanned
     and (
         parse_datetime(dt, 'yyyy-MM-dd-HH-mm')
         between date_add('day', -3, current_timestamp) and current_timestamp
     )
-),
-latest_file_dates as (
-    select
-        key,
-        max(last_modified_date) as max_date
-    from aip_files
-    where is_latest = true and is_delete_marker = false
-    group by key
 )
 select
-    af.key,
-    af.checksum_algorithm
-from aip_files af
-inner join latest_file_dates lf on
-    af.key = lf.key and
-    af.last_modified_date = lf.max_date
-;
+    key,
+    checksum_algorithm
+from date_ordered_files
+where rn = 1
+and is_latest = true
+and is_delete_marker = false

--- a/lambdas/utils/aws/s3.py
+++ b/lambdas/utils/aws/s3.py
@@ -80,7 +80,7 @@ class S3Client:
     @classmethod
     def generate_checksum_for_object(cls, s3_uri: str) -> str:
         """Generate a SHA256 checksum for an S3 object by copying it over itself."""
-        logger.info(f"Generating checksum for: {s3_uri}")
+        logger.debug(f"Generating checksum for: {s3_uri}")
         bucket, key = cls.parse_s3_uri(s3_uri)
         s3_client = cls.get_client()
 

--- a/lambdas/validator.py
+++ b/lambdas/validator.py
@@ -17,6 +17,7 @@ class InputPayload:
     aip_s3_uri: str
     challenge_secret: str
     verbose: bool = False
+    num_workers: int = 4
 
 
 def lambda_handler(event: dict, _context: dict) -> dict:
@@ -48,7 +49,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
     # validate AIP
     aip = AIP(payload.aip_s3_uri)
     try:
-        result = aip.validate()
+        result = aip.validate(num_workers=payload.num_workers)
     except Exception as exc:  # noqa: BLE001
         logger.error(exc)  # noqa: TRY400
         return generate_error_response(str(exc), HTTPStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
### Purpose and background context

This PR parallelizes the retrieveal and/or generation of checksums for files.  This is achieved by parallel threads performing AWS operations.

An AIP was encountered in Dev, `s3://cdps-storage-dev-222053980223-aipstore5b/5b33/1bf3/eb1f/4017/bbe8/c24a/9f60/f4cd/2014_039_002-5b331bf3-eb1f-4017-bbe8-c24a9f60f4cd/`, that had over 8k files in the `/data` folder.  Performing that work sequentially was timing out 15 minute lambdas.  Performing that work in parallel -- with anywhere from 256 to 512 threads -- is finishing in around 6-7 minutes (maybe faster in deployed form).  While ~7 minutes is a very long time for an HTTP request, it nonetheless completes.  When performing these AIP validations at scale, it's unlikely that many will have that many files, but this will allow them to complete.

Additionally, per commit XYZ, the Athena SQL query was optimized to reduce data scanned.

### How can a reviewer manually see the effects of these changes?

TODO...

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: lambda will not time out, Athena queries fastesr

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IR-193

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes