### PR TITLE
Unset env var AIP_VALIDATOR_ENDPOINT for unit testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ def _test_env(monkeypatch, request):
     monkeypatch.setenv("WORKSPACE", "test")
     monkeypatch.setenv("SENTRY_DSN", "None")
     monkeypatch.setenv("CHALLENGE_SECRET", "i-am-secret")
+    monkeypatch.delenv("AIP_VALIDATOR_ENDPOINT", raising=False)
 
     # do not set for integration tests
     if not request.node.get_closest_marker("integration"):


### PR DESCRIPTION
### Purpose and background context

This PR unsets an env var, if set, before running unit tests.  Unsetting `AIP_VALIDATOR_ENDPOINT` ensures that the lambda is not invoked during CLI unit tests.

### How can a reviewer manually see the effects of these changes?

Run `make tests` and, if desired, confirm in AWS lambda/cloudwatch that lambda did not run.

Optional AWS CLI command to monitor logs:
```shell
aws logs tail /aws/lambda/s3-bagit-validator-dev --follow
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: lambda not invoked

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes