### PR TITLE
IR-209 - Gracefully handle missing or empty S3 inventory location

### DIFF
--- a/tests/test_s3_inventory.py
+++ b/tests/test_s3_inventory.py
@@ -63,6 +63,16 @@ class TestS3InventoryClientParquetFiles:
                 assert "s3://bucket/inventory/dt=2023-04-15-00-00/data1.parquet" in result
                 assert "s3://bucket/inventory/dt=2023-04-15-00-00/data2.parquet" in result
 
+    def test_get_single_inventory_parquet_files_inventory_missing_or_empty(
+        self, caplog, mock_s3_client
+    ):
+        client = S3InventoryClient()
+        with patch.object(client.s3_client, "list_objects_recursive") as mock_list:
+            mock_list.return_value = []
+            result = client.get_single_inventory_parquet_files("s3://bucket/inventory")
+            assert result == []
+            assert "No symlink.txt files found for inventory location" in caplog.text
+
     def test_get_all_inventory_parquet_files(self):
         client = S3InventoryClient(
             inventory_uris=["s3://bucket1/inventory", "s3://bucket2/inventory"]


### PR DESCRIPTION
### Purpose and background context

This PR addresses two edge cases:

1. a configured S3 inventoy prefix truly does not exist (nothing at that key or under that prefix)
2. a configured S3 inventory prefix exists, but no inventory data has been written there

Because the inventory location is a prefix, and not an actual object, we need to be a little careful saying it "exists" or not.  And, theoretically they could be empty (e.g. inventory for buckets with no objects yet).

This fix handles these cases in two ways:

1. log a **warning** that the configured location either does not exist or is empty (should be rare)
2. returns an empty list of "most recent" parquet files allowing program to continue

If we do attempt to validate an AIP that should have inventory data, but the inventory data can't be found, an error downstream will get thrown.  In this way, the warning log message would be a critical clue for why an AIP couldn't be validated because inventory data couldn't be found for one or more configured inventory locations.

### How can a reviewer manually see the effects of these changes?

1- Set AWS admin credentials and env vars
```shell
WORKSPACE=dev
S3_INVENTORY_LOCATIONS="s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore1b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore2b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore3b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore4b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore5b"
```

2- Start Ipython shell
```shell
pipenv run ipython
```

3- Run some examples:
```python
from lambdas.config import configure_dev_logger
from lambdas.utils.aws import S3InventoryClient

configure_dev_logger()

client = S3InventoryClient()

# valid; returns parquet file(s)
client.get_single_inventory_parquet_files("s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore4b")

# real location with actual files, but simulates no hive symlinks; logs warning
client.get_single_inventory_parquet_files("s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore4b/data")

# prefix with no objects; logs warning
client.get_single_inventory_parquet_files("s3://cdps-dev-inventory-222053980223/inventory/does-not-exist")
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IR-209

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes