### PR TITLE
Bubble up handled exceptions into lambda response

### DIFF
--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -268,9 +268,8 @@ def validate_aip_via_lambda(
             "aip_s3_uri": aip_s3_uri,
             "verbose": verbose,
         },
-        timeout=900,  # long 15 min timeout for large AIPs
+        timeout=900,  # 15 min timeout (AWS Lambda maximum) for large AIPs
     )
-    response.raise_for_status()
     result = response.json()
 
     status = "OK" if result.get("valid", False) else f"FAILED: {result.get('error')}"


### PR DESCRIPTION
### Purpose and background context

Why these changes are being introduced:

It was pointed out that even for some handled exceptions (e.g. a bad UUID) the error message returned by the Lambda + CLI was still opaque.  Effort had gone into catching those cases and providing meaningful python Exceptions, but they weren't getting returned by the Lambda.

Turns out the CLI has some copy pasta for requests that was raising an exception based on a HTTP status code, which was short-circuiting the returning of those curated exceptions.

How this addresses that need:

Remove the `.raise_for_status()` call in the CLI which allows the exceptions to get returned in the Lambda response.  Also, improve exception handling to expose when a UUID is not found.

Side effects of this change:
* Lambda, and by proxy CLI, responses are improved with more details when something fails

### How can a reviewer manually see the effects of these changes?

1- Turn on VPN

2- Set env vars:
```shell
WORKSPACE=dev
CHALLENGE_SECRET=pickles
AIP_VALIDATOR_ENDPOINT=https://s3-bagit-validator.dev1.mitlibrary.net/
```

3- Perform CLI commands for some known error cases:
```shell
## AIP missing
pipenv run cli validate --aip-uuid="4b064dbd-1492-4ff7-a853-ab28e9c2fc7x"

## not a valid bag
pipenv run cli validate --aip-uuid="5235eaf1-cc28-43c8-8eb7-be0392eea337"

## does not exist
pipenv run cli validate --s3-uri="s3://cdps-storage-dev-222053980223-aipstore4b/does/not/exist"
```

Formerly -- at least in most cases -- an opaque error was returned.  Now the CLI is allowing the error responses to pass through.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes