### PR TITLE
IR 210 -  large file checksumming

### DIFF
--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -248,9 +248,16 @@ class AIP:
                 f"{self.s3_key}/{filepath}"
             ]
 
-            # retrieve or generate SHA256
-            if inventory_row["checksum_algorithm"] != "SHA256":
+            # derive a SHA256 checksum for file
+            ## case: S3 objects >= 5gb
+            if inventory_row["size"] > 5 * 1024 * 1024 * 1024:  # 5 GB
+                base64_checksum = self.s3_client.calculate_checksum_for_large_object(
+                    s3_uri
+                )
+            ## case: S3 object does not have a SHA256 checksum available
+            elif inventory_row["checksum_algorithm"] != "SHA256":
                 base64_checksum = self.s3_client.generate_checksum_for_object(s3_uri)
+            ## case: S3 object has a SHA256 checksum available
             else:
                 base64_checksum = self.s3_client.get_checksum_for_object(s3_uri)
 

--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -227,11 +227,30 @@ class AIP:
     def _get_aip_file_checksums(
         self, num_workers: int = CONFIG.checksum_num_workers
     ) -> dict[str, str]:
-        """Retrieve checksums for all files listed in Bagit manifest.
+        """Get checksums for all files listed in Bagit manifest.
 
-        If a SHA256 checksum does not exist, generate one by copying the object onto
-        itself.  This process is performed in parallel via threads by the worker function
+        This process is performed in parallel via threads by the worker function
         'process_file_worker' which updates a local dictionary of file-to-checksum.
+
+        The mechanism by which we get a checksum for a file varies per the S3 object:
+
+            - case 1: S3 objects >= 5gb
+                - use S3Client.calculate_checksum_for_large_object()
+                - we must calculate a checksum manually from the object bytes
+                - files this large cannot be copied via boto3.s3.copy_object(), and thus
+                we cannot get a checksum per that approach
+                - moreover, files this large cannot have "full" SHA256 checksums in AWS,
+                only "composite" which is not the same as a Bagit checksum for the file
+
+            - case 2: S3 object does not have a SHA256 checksum available
+                - use S3Client.generate_checksum_for_object()
+                - if the file is < 5gb, we can use boto3.s3.copy_object() to copy the file
+                 over itself, returning a SHA256 checksum in the process and saving it to
+                 the object for future use
+
+            - case 3: S3 object has a SHA256 checksum available
+                - use S3Client.get_checksum_for_object()
+                - the object already has a SHA256 checksum, use it
         """
         if self.manifest_df is None:
             raise ValueError("Bagit manifest data not found")
@@ -249,15 +268,15 @@ class AIP:
             ]
 
             # derive a SHA256 checksum for file
-            ## case: S3 objects >= 5gb
+            ## S3 objects >= 5gb
             if inventory_row["size"] > 5 * 1024 * 1024 * 1024:  # 5 GB
                 base64_checksum = self.s3_client.calculate_checksum_for_large_object(
                     s3_uri
                 )
-            ## case: S3 object does not have a SHA256 checksum available
+            ## S3 object does not have a SHA256 checksum via metadata
             elif inventory_row["checksum_algorithm"] != "SHA256":
                 base64_checksum = self.s3_client.generate_checksum_for_object(s3_uri)
-            ## case: S3 object has a SHA256 checksum available
+            ## S3 object has a SHA256 checksum available via metadata
             else:
                 base64_checksum = self.s3_client.get_checksum_for_object(s3_uri)
 

--- a/lambdas/utils/aws/s3.py
+++ b/lambdas/utils/aws/s3.py
@@ -1,4 +1,10 @@
+# ruff: noqa: D417
+
+import base64
+import hashlib
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -96,7 +102,7 @@ class S3Client:
     def get_checksum_for_object(cls, s3_uri: str) -> str:
         """Get the SHA256 checksum for an S3 object."""
         bucket, key = cls.parse_s3_uri(s3_uri)
-        s3_client = boto3.client("s3")
+        s3_client = cls.get_client()
 
         head_response = s3_client.head_object(
             Bucket=bucket, Key=key, ChecksumMode="ENABLED"
@@ -105,3 +111,106 @@ class S3Client:
         if "ChecksumSHA256" in head_response:
             return head_response["ChecksumSHA256"]
         raise ValueError(f"Object does not have a SHA256 checksum: {s3_uri}")
+
+    @classmethod
+    def get_object_size(
+        cls,
+        bucket: str,
+        key: str,
+    ) -> int:
+        s3_client = cls.get_client()
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+        return head["ContentLength"]
+
+    @classmethod
+    def download_object_byte_range(
+        cls,
+        bucket: str,
+        key: str,
+        file_size: int,
+        chunk_index: int,
+        chunk_size: int,
+    ) -> bytes:
+        """Download a byte range chunk from an S3 object.
+
+        This method calculates the start/end byte ranges based on the file size, chunk
+        size, and chunk index requested.
+        """
+        s3_client = cls.get_client()
+
+        start = chunk_index * chunk_size
+        end = min(start + chunk_size, file_size)
+        range_header = f"bytes={start}-{end - 1}"
+
+        resp = s3_client.get_object(Bucket=bucket, Key=key, Range=range_header)
+        return resp["Body"].read()
+
+    @classmethod
+    def calculate_checksum_for_large_object(
+        cls,
+        s3_uri: str,
+        window_size: int = 40,
+        chunk_size: int = 10 * 1024 * 1024,  # 10 MB
+    ) -> str:
+        """Calculate SHA256 checksum for a large (>= 5gb) S3 object.
+
+        This method is useful for objects >= 5gb, where boto3's copy_object() is not
+        supported (used by class method generate_checksum_for_object()).  Instead, we are
+        forced to calculate a checksum ourselves based on the content of the file.
+
+        This method streams byte ranges in PARALLEL, but then hashes the bytes in ORDER,
+        producing an accurate checksum.  This is sometimes called a "Scatter/Gather"
+        approach, common in map reduce pipelines.  By using ThreadPoolExecutor.map(), we
+        are guaranteed that we are hashing the bytes in order from the original file,
+        while still performing some parallel downloading of bytes which considerably
+        speeds up the process.
+
+        This method does not ever store the full file in memory.  The memory pressure
+        exerted is roughly equal to window_size * chunk_size (e.g. 40 * 10mb = 400mb).
+
+        Args:
+            - s3_uri: [str] S3 URI of object
+            - window_size: [int] Number of chunks to download and hash in parallel
+            - chunk_size: [int] Size in bytes for each chunk of the file downloaded
+        """
+        start_time = time.perf_counter()
+        bucket, key = cls.parse_s3_uri(s3_uri)
+
+        file_size = cls.get_object_size(bucket, key)
+        num_chunks = (file_size + chunk_size - 1) // chunk_size
+        hasher = hashlib.sha256()
+
+        with ThreadPoolExecutor(max_workers=window_size) as executor:
+            # prepare list of byte ranges for chunks that will
+            # get passed to .download_object_byte_range()
+            download_chunk_args = [
+                (bucket, key, file_size, chunk_index, chunk_size)
+                for chunk_index in range(num_chunks)
+            ]
+
+            # execute downloads in parallel, but receive results
+            # in order via usage of .map()
+            for chunk_index, chunk_data in enumerate(
+                executor.map(
+                    lambda args: cls.download_object_byte_range(*args),
+                    download_chunk_args,
+                )
+            ):
+                # update checksum based on next contiguous chunk of bytes
+                hasher.update(chunk_data)
+
+                # log progress at roughly 10% intervals
+                progress_percentage = ((chunk_index + 1) / num_chunks) * 100
+                if progress_percentage % 10 < (1 / num_chunks) * 100:
+                    logger.debug(
+                        f"{int(progress_percentage)}% "
+                        f"({(chunk_index + 1)}/{num_chunks} chunks) "
+                        f"complete for '{s3_uri}'"
+                    )
+
+        base64_checksum = base64.b64encode(hasher.digest()).decode("ascii")
+        logger.debug(
+            f"Large file get checksum elapsed: {time.perf_counter() - start_time:.2f}s, "
+            f"s3_uri: '{s3_uri}'."
+        )
+        return base64_checksum

--- a/lambdas/utils/aws/s3.py
+++ b/lambdas/utils/aws/s3.py
@@ -85,7 +85,11 @@ class S3Client:
 
     @classmethod
     def generate_checksum_for_object(cls, s3_uri: str) -> str:
-        """Generate a SHA256 checksum for an S3 object by copying it over itself."""
+        """Generate a SHA256 checksum for an S3 object by copying it over itself.
+
+        In addition to returning  the SHA256 checksum, this also saves the checksum to the
+        object metadata such that it can be quickly retrieved in the future.
+        """
         logger.debug(f"Generating checksum for: {s3_uri}")
         bucket, key = cls.parse_s3_uri(s3_uri)
         s3_client = cls.get_client()
@@ -100,7 +104,7 @@ class S3Client:
 
     @classmethod
     def get_checksum_for_object(cls, s3_uri: str) -> str:
-        """Get the SHA256 checksum for an S3 object."""
+        """Get the SHA256 checksum for an S3 object from its Metadata."""
         bucket, key = cls.parse_s3_uri(s3_uri)
         s3_client = cls.get_client()
 

--- a/lambdas/utils/aws/s3_inventory.py
+++ b/lambdas/utils/aws/s3_inventory.py
@@ -290,7 +290,9 @@ class S3InventoryClient:
             last_modified_date,
             filename,
             key,
-            checksum_algorithm
+            checksum_algorithm,
+            size,
+            is_multipart_uploaded
         from inventory
 
         -- ensures data is only for most recent form of record and not deleted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,21 @@ def mock_aip_files():
 
 @pytest.fixture
 def mock_inventory_data():
+    one_mb_size = 1 * 1024 * 1024
     df = pd.DataFrame(
         [
-            {"key": "aip/data/file1.txt", "checksum_algorithm": "SHA256"},
-            {"key": "aip/data/file2.txt", "checksum_algorithm": "SHA256"},
+            {
+                "key": "aip/data/file1.txt",
+                "checksum_algorithm": "SHA256",
+                "size": one_mb_size,
+                "is_multipart_uploaded": False,
+            },
+            {
+                "key": "aip/data/file2.txt",
+                "checksum_algorithm": "SHA256",
+                "size": one_mb_size,
+                "is_multipart_uploaded": False,
+            },
         ]
     )
     with patch("lambdas.utils.aws.S3InventoryClient.get_aip_inventory") as mock_query:

--- a/tests/test_aip.py
+++ b/tests/test_aip.py
@@ -232,11 +232,27 @@ class TestAIP:
             ]
         )
 
+        one_mb_size = 1 * 1024 * 1024
         aip.s3_inventory = pd.DataFrame(
             [
-                {"key": "aip/data/file1.txt", "checksum_algorithm": "SHA256"},
-                {"key": "aip/data/file2.txt", "checksum_algorithm": "SHA256"},
-                {"key": "aip/data/file3.txt", "checksum_algorithm": "MD5"},
+                {
+                    "key": "aip/data/file1.txt",
+                    "checksum_algorithm": "SHA256",
+                    "size": one_mb_size,
+                    "is_multipart_uploaded": False,
+                },
+                {
+                    "key": "aip/data/file2.txt",
+                    "checksum_algorithm": "SHA256",
+                    "size": one_mb_size,
+                    "is_multipart_uploaded": False,
+                },
+                {
+                    "key": "aip/data/file3.txt",
+                    "checksum_algorithm": "MD5",
+                    "size": one_mb_size,
+                    "is_multipart_uploaded": False,
+                },
             ]
         ).set_index("key")
 


### PR DESCRIPTION
### Purpose and background context

This PR adds support for calculating checksums for large (>= 5gb) files in S3, thereby allowing this tool to validate AIPs with large single files.

See commit message for details about how this new functionality works.

When this tool encounters large files in an AIP, and it switches over to using this method, memory will likely increase relative to other methods.  If an AIP has 2-3 large files, this is mostly inconsequential.  But there is a theoretical limit: if an AIP had 15-20 files @ 5-10gb each, because we do _that_ checksumming in parallel as well, it's possible we could exceed the lambda memory resources.  A document is getting created that will outline some of these theoretical limits, but for now, I would propose we acknowledge them bu move forward with this implementation that is known to solve for a large number (if not all) of our AIPs with large, single files.

### How can a reviewer manually see the effects of these changes?

1- Set Dev AWS credentials

2- Set env vars (required for app, but technically not this testing):
```shell
WORKSPACE=dev
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,pyathena
CHALLENGE_SECRET=pickles
S3_INVENTORY_LOCATIONS="s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore1b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore2b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore3b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore4b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore5b"
```

3- Start ipython shell for some hands on testing:
```shell
pipenv run ipython
```

4- Calculate the checksum for a single 1.1gb file:
```python
from lambdas.aip import *
from lambdas.config import configure_dev_logger

configure_dev_logger()

s3_client = S3Client()

checksum_a = s3_client.calculate_checksum_for_large_object("s3://ghukill-test/apt-testing/large-1gb-file.xml")
```
- depending on network connection, should take anywhere from 10-20 seconds; this is considerably faster then if all bytes were downloaded and hashed sequentially via one thread/process/worker
- if interested, a larger 5.1gb file can be found here: `s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/single-large-file/single-large-file/data/bigfile.dat`

5- Confirm this checksum is correct by using another method, which works for this 1.1gb file (less than 5gb):
```python
checksum_b = s3_client.generate_checksum_for_object("s3://ghukill-test/apt-testing/large-1gb-file.xml")
assert checksum_a == checksum_b
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: ideally, no errors when encountering files >= 5gb

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IR-210

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes