### PR TITLE
IR 220 - manifests and error details

### DIFF
--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -30,6 +30,7 @@ class ValidationResponse:
         elapsed: time in seconds to perform validation
         manifest: dictionary of manifest file to its checksum
         error: string of error(s) if encountered during validation
+        error_details: dictionary of details related to validation error(s)
     """
 
     s3_uri: str
@@ -37,12 +38,26 @@ class ValidationResponse:
     elapsed: float
     manifest: dict[str, str] | None = None
     error: str | None = None
+    error_details: dict | None = None
 
-    def to_dict(self) -> dict:
-        return asdict(self)
+    def to_dict(
+        self,
+        include: list[str] | None = None,
+        exclude: list[str] | None = None,
+    ) -> dict:
+        output = asdict(self)
+        if include:
+            output = {k: v for k, v in output.items() if k in include}
+        if exclude:
+            output = {k: v for k, v in output.items() if k not in exclude}
+        return output
 
-    def to_json(self) -> str:
-        return json.dumps(self.to_dict())
+    def to_json(
+        self,
+        include: list[str] | None = None,
+        exclude: list[str] | None = None,
+    ) -> str:
+        return json.dumps(self.to_dict(include=include, exclude=exclude))
 
 
 class AIP:

--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -222,8 +222,7 @@ class AIP:
         if missing_in_aip:
             missing_files = list(missing_in_aip)
             raise AIPValidationError(
-                "Files found in manifest but missing from AIP: "
-                + json.dumps(missing_files),
+                "Files found in manifest but missing from AIP",
                 error_details={
                     "type": "files_missing_in_aip",
                     "missing_files": missing_files,
@@ -232,8 +231,7 @@ class AIP:
         if missing_in_manifest:
             missing_files = list(missing_in_manifest)
             raise AIPValidationError(
-                "Files found in AIP but missing from manifest: "
-                + json.dumps(missing_files),
+                "Files found in AIP but missing from manifest",
                 error_details={
                     "type": "files_missing_in_manifest",
                     "missing_files": missing_files,

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -282,7 +282,7 @@ def validate_aip_via_lambda(
     )
 
     if response.status_code != HTTPStatus.OK:
-        raise RuntimeError(f"Non 200 response from Lambda: {response.content.decode()}")
+        logger.warning(f"Non 200 response from Lambda: {response.content.decode()}")
 
     try:
         result = response.json()

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -125,7 +125,15 @@ def validate(ctx: click.Context, aip_uuid: str, s3_uri: str, *, details: bool) -
             click.echo("OK")
         ctx.exit(0)
     else:
-        click.echo(f"AIP validation error: {result.get('error', 'Unknown')}", err=True)
+        click.echo(
+            json.dumps(
+                {
+                    "error": result.get("error", "Unspecified"),
+                    "error_details": result.get("error_details", None),
+                }
+            ),
+            err=True,
+        )
         ctx.exit(1)
 
 

--- a/lambdas/exceptions.py
+++ b/lambdas/exceptions.py
@@ -1,2 +1,12 @@
 class AIPValidationError(Exception):
     """Raised when AIP validation fails."""
+
+    def __init__(self, message: str, error_details: dict | None = None):
+        """Initialize AIPValidationError with a message and optional error details.
+
+        Args:
+            message: Error message
+            error_details: Dictionary with additional error details
+        """
+        super().__init__(message)
+        self.error_details = error_details or {}

--- a/lambdas/utils/aws/s3.py
+++ b/lambdas/utils/aws/s3.py
@@ -105,6 +105,7 @@ class S3Client:
     @classmethod
     def get_checksum_for_object(cls, s3_uri: str) -> str:
         """Get the SHA256 checksum for an S3 object from its Metadata."""
+        logger.debug(f"Getting checksum for: {s3_uri}")
         bucket, key = cls.parse_s3_uri(s3_uri)
         s3_client = cls.get_client()
 
@@ -177,6 +178,7 @@ class S3Client:
             - window_size: [int] Number of chunks to download and hash in parallel
             - chunk_size: [int] Size in bytes for each chunk of the file downloaded
         """
+        logger.debug(f"Calculating checksum for: {s3_uri}")
         start_time = time.perf_counter()
         bucket, key = cls.parse_s3_uri(s3_uri)
 

--- a/lambdas/validator.py
+++ b/lambdas/validator.py
@@ -152,4 +152,6 @@ def validate(payload: InputPayload) -> dict:
         raise RuntimeError("Either AIP S3 URI or UUID is required.")
 
     result = aip.validate(num_workers=payload.num_workers)
-    return generate_result_response(result.to_dict())
+    logger.info(f"AIP '{result.s3_uri}' is valid: {result.valid}")
+
+    return generate_result_response(result.to_dict(exclude=["manifest"]))

--- a/tests/test_aip.py
+++ b/tests/test_aip.py
@@ -154,6 +154,10 @@ class TestAIP:
 
             assert response.valid is False
             assert response.error == "Bagit AIP folder not found in S3: s3://bucket/aip"
+            assert response.error_details == {
+                "type": "aip_folder_not_found",
+                "s3_uri": "s3://bucket/aip",
+            }
 
     def test_check_aip_files_match_manifest_missing_files(
         self, mock_aip_folder, mock_manifest_data
@@ -176,10 +180,10 @@ class TestAIP:
             "data/file2.txt",
         ]
 
-        with pytest.raises(AIPValidationError) as excinfo:
+        with pytest.raises(AIPValidationError) as exc:
             aip._check_aip_files_match_manifest()
 
-        assert "Files found in manifest but missing from AIP" in str(excinfo.value)
+        assert "Files found in manifest but missing from AIP" in str(exc.value)
 
     def test_check_aip_files_match_manifest_extra_files(
         self, mock_aip_folder, mock_manifest_data
@@ -195,10 +199,10 @@ class TestAIP:
             "data/file2.txt",
         ]
 
-        with pytest.raises(AIPValidationError) as excinfo:
+        with pytest.raises(AIPValidationError) as exc:
             aip._check_aip_files_match_manifest()
 
-        assert "Files found in AIP but missing from manifest" in str(excinfo.value)
+        assert "Files found in AIP but missing from manifest" in str(exc.value)
 
     def test_check_checksums_mismatch(self):
         aip = AIP("s3://bucket/aip")
@@ -213,11 +217,11 @@ class TestAIP:
             "data/file2.txt": "wrong",  # Doesn't match
         }
 
-        with pytest.raises(AIPValidationError) as excinfo:
+        with pytest.raises(AIPValidationError) as exc:
             aip._check_checksums()
 
-        assert "Mismatched checksums for files" in str(excinfo.value)
-        assert "data/file2.txt" in str(excinfo.value)
+        assert "Mismatched checksums for files" in str(exc.value)
+        assert "data/file2.txt" in exc.value.error_details["mismatched_files"]
 
     def test_get_aip_file_checksums(self):
         """Test that _get_aip_file_checksums correctly processes files in parallel."""
@@ -366,6 +370,10 @@ class TestAIPIntegration:
             f"S3 Inventory data not found for S3 key: '{integration_prefix}/valid-aip'"
             in result.error
         )
+        assert result.error_details == {
+            "type": "s3_inventory_not_found",
+            "s3_key": f"{integration_prefix}/valid-aip",
+        }
 
     @pytest.mark.parametrize(
         "test_case",
@@ -380,6 +388,10 @@ class TestAIPIntegration:
                     }
                 ],
                 "expected_error": 'Files found in manifest but missing from AIP: ["data/file1.txt"]',
+                "expected_error_details": {
+                    "type": "files_missing_in_aip",
+                    "missing_files": ["data/file1.txt"],
+                },
             },
             {
                 "fixture_path": "tests/fixtures/aips/missing-file-in-manifest",
@@ -394,6 +406,10 @@ class TestAIPIntegration:
                     },
                 ],
                 "expected_error": 'Files found in AIP but missing from manifest: ["data/file1.txt"]',
+                "expected_error_details": {
+                    "type": "files_missing_in_manifest",
+                    "missing_files": ["data/file1.txt"],
+                },
             },
             {
                 "fixture_path": "tests/fixtures/aips/checksum-mismatch",
@@ -404,6 +420,14 @@ class TestAIPIntegration:
                     }
                 ],
                 "expected_error": 'Mismatched checksums for files: ["data/file1.txt"]',
+                "expected_error_details": {
+                    "type": "checksum_mismatch",
+                    "mismatched_files": ["data/file1.txt"],
+                    "manifest_checksums": {
+                        "data/file1.txt": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "s3_checksums": {"data/file1.txt": "different_checksum"},
+                },
             },
         ],
         ids=["missing-file-in-aip", "missing-file-in-manifest", "checksum-mismatch"],
@@ -427,7 +451,33 @@ class TestAIPIntegration:
 
         with patch.object(aip, "_get_aip_s3_inventory") as mocked_inventory:
             mocked_inventory.return_value = pd.DataFrame(inventory_data).set_index("key")
-            result = aip.validate()
+
+            # for checksum mismatch test, we need to mock the checksums
+            if "checksum-mismatch" in fixture_path:
+                with patch.object(aip, "_get_aip_file_checksums") as mock_checksums:
+                    mock_checksums.return_value = {"data/file1.txt": "different_checksum"}
+                    result = aip.validate()
+            else:
+                result = aip.validate()
 
         assert not result.valid
         assert result.error == test_case["expected_error"]
+
+        # check that error_details has the expected structure
+        expected_error_details = test_case["expected_error_details"]
+        assert result.error_details["type"] == expected_error_details["type"]
+
+        # check specific fields based on error type
+        if (
+            expected_error_details["type"] == "files_missing_in_aip"
+            or expected_error_details["type"] == "files_missing_in_manifest"
+        ):
+            assert set(result.error_details["missing_files"]) == set(
+                expected_error_details["missing_files"]
+            )
+        elif expected_error_details["type"] == "checksum_mismatch":
+            assert set(result.error_details["mismatched_files"]) == set(
+                expected_error_details["mismatched_files"]
+            )
+            assert "manifest_checksums" in result.error_details
+            assert "s3_checksums" in result.error_details

--- a/tests/test_aip.py
+++ b/tests/test_aip.py
@@ -40,11 +40,10 @@ class TestValidationResponse:
 
     def test_to_json(self):
         response = ValidationResponse(s3_uri="s3://bucket/aip", valid=True, elapsed=1.5)
-        json_result = response.to_json()
+        json_result = response.to_json(exclude=["manifest", "error", "error_details"])
         assert isinstance(json_result, str)
         assert (
-            json_result
-            == '{"s3_uri": "s3://bucket/aip", "valid": true, "elapsed": 1.5, "manifest": null, "error": null}'
+            json_result == '{"s3_uri": "s3://bucket/aip", "valid": true, "elapsed": 1.5}'
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,11 +82,15 @@ class TestValidateCommand:
     def test_validate_command_failure(self):
         runner = CliRunner()
         with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
-            mock_validate.return_value = {"valid": False, "error": "Validation failed"}
+            mock_validate.return_value = {
+                "valid": False,
+                "error": "Validation failed",
+                "error_details": {"problem": "serious"},
+            }
 
             result = runner.invoke(cli, ["validate", "--aip-uuid", "test-uuid"])
             assert result.exit_code == 1
-            assert "AIP validation error: Validation failed" in result.output
+            assert "Validation failed" in result.output
 
     def test_validate_missing_required_args(self):
         cli_usage_error = 2
@@ -170,7 +174,10 @@ class TestValidateAipViaLambda:
             mock_post.return_value = mock_response
 
             result = validate_aip_via_lambda(aip_uuid="test-uuid")
-            assert result == {"valid": True, "elapsed": 1.5}
+            assert result == {
+                "valid": True,
+                "elapsed": 1.5,
+            }
 
             args, kwargs = mock_post.call_args
             assert kwargs["json"]["aip_uuid"] == "test-uuid"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,6 +165,7 @@ class TestValidateAipViaLambda:
     def test_validate_aip_via_lambda_with_uuid(self):
         with patch("requests.post") as mock_post:
             mock_response = MagicMock()
+            mock_response.status_code = 200
             mock_response.json.return_value = {"valid": True, "elapsed": 1.5}
             mock_post.return_value = mock_response
 
@@ -178,6 +179,7 @@ class TestValidateAipViaLambda:
     def test_validate_aip_via_lambda_with_s3_uri(self):
         with patch("requests.post") as mock_post:
             mock_response = MagicMock()
+            mock_response.status_code = 200
             mock_response.json.return_value = {"valid": True, "elapsed": 1.5}
             mock_post.return_value = mock_response
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -150,7 +150,6 @@ class TestLambdaHandler:
         body = json.loads(response["body"])
         assert body["valid"] is True
         assert body["s3_uri"] == "s3://bucket/aip"
-        assert body["manifest"] == {"data/file1.txt": "abc123"}
 
     def test_lambda_handler_success_with_uuid(self):
         event = {

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -105,17 +105,23 @@ class TestValidateSecret:
 class TestResponseGeneration:
     def test_generate_error_response(self):
         response = validator.generate_error_response(
-            "Test error message", HTTPStatus.BAD_REQUEST
+            "Test error message", http_status_code=HTTPStatus.BAD_REQUEST
         )
         assert response["statusCode"] == HTTPStatus.BAD_REQUEST
         assert response["headers"] == {"Content-Type": "application/json"}
         assert response["isBase64Encoded"] is False
-        assert json.loads(response["body"]) == {"error": "Test error message"}
+        assert json.loads(response["body"]) == {
+            "error": "Test error message",
+            "error_details": None,
+        }
 
     def test_generate_error_response_default_status(self):
         response = validator.generate_error_response("Test error message")
         assert response["statusCode"] == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert json.loads(response["body"]) == {"error": "Test error message"}
+        assert json.loads(response["body"]) == {
+            "error": "Test error message",
+            "error_details": None,
+        }
 
     def test_generate_result_response(self):
         test_data = {"key": "value", "nested": {"data": 123}}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -76,9 +76,9 @@ class TestReadS3Object:
     def test_read_s3_object_not_found(self, mock_s3_client):
         error_response = {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}}
         mock_s3_client.get_object.side_effect = ClientError(error_response, "GetObject")
-        with pytest.raises(ClientError) as excinfo:
+        with pytest.raises(ClientError) as exc:
             S3Client.read_s3_object("s3://bucket/file.txt")
-        assert "NoSuchKey" in str(excinfo.value)
+        assert "NoSuchKey" in str(exc.value)
 
 
 class TestChecksumMethods:
@@ -98,9 +98,9 @@ class TestChecksumMethods:
     def test_generate_checksum_for_object_error(self, mock_s3_client):
         error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
         mock_s3_client.copy_object.side_effect = ClientError(error_response, "CopyObject")
-        with pytest.raises(ClientError) as excinfo:
+        with pytest.raises(ClientError) as exc:
             S3Client.generate_checksum_for_object("s3://bucket/file.txt")
-        assert "AccessDenied" in str(excinfo.value)
+        assert "AccessDenied" in str(exc.value)
 
     def test_get_checksum_for_object_success(self, mock_s3_client):
         mock_s3_client.head_object.return_value = {"ChecksumSHA256": "abc123checksum"}


### PR DESCRIPTION
### Purpose and background context

This PR implements two primary changes:
- **removal** of the `manifest` object from the Lambda/CLI response
- **addition** of an `error_details` object to the Lambda/CLI response

The inspiration is linked, but somewhat distinct.

The removal of the `manifest` from the response payload is primary to workaround the 1mb response limit of a Lambda sitting behind an Automatic Load Balancer (ALB).  This is fairly small, and was exceeded for AIPs with large numbers of files (e.g. `b7ad7d08-de96-4d04-83c9-0d2c6a6d80e8` in stage).  This was preventing the Lambda from returning a result; a fairly opaque error that was hard to trace.

With that information loss, it was equally important to expose more details about validations failures if they occurred.  This is handled with a new `error_details` object that contains details like:
- what files had bad checksums
- what files were missing from the AIP and/or manifest
- etc.

The new `error_details` object should provide enough information for consumes of the Lambda or the CLI (which calls the Lambda) to inform next steps for addressing the validation failure.

**It is recommended to review by commits, which are fairly encapsulated.**

### How can a reviewer manually see the effects of these changes?

The best way is probably to run the CLI and work through some canned scenarios.

First:
- set AWS admin dev credentials
- turn on VPN
- set the following env vars:

```shell
WORKSPACE=dev
CHALLENGE_SECRET=pickles
AIP_VALIDATOR_ENDPOINT=https://s3-bagit-validator.dev1.mitlibrary.net/
```

**1- SUCCESS: valid AIP with details**
```shell
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/valid-aip/ --details
```
- note the full response via `--details` is still fairly minimal, no longer containing the `manifest`

**2- ERROR: various errors encountered when running validations**
```shell
# Bad AIP UUID
pipenv run cli validate --aip-uuid=b7ad7d08-de96-4d04-83c9-XXXXXXXXXXXX

# Bad AIP S3 URI
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/i-do-no-exist/

# Bad checksums
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/checksum-mismatch/

# Missing files in AIP
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/missing-file-in-aip/

# Missing files in manifest
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/missing-file-in-manifest/
```
- note that even without `--details`, we see the error reason + details (which was requested by testers)
- in theory `error` + `error_details` is enough for users to understand what went wrong

**3- SUCCESS: AIP with very large single file (>5gb, takes 1-2 minutes)**
```shell
pipenv run cli validate --s3-uri=s3://cdps-storage-dev-aipstore1b/s3-bagit-validator-test-aips/checksum-mismatch
```
- uses relatively new checksumming approach of a large single file

**4- SUCCESS: AIP with lots of files (8k+, takes about 1-2minutes)**
```shell
pipenv run cli --verbose validate --s3-uri=s3://cdps-storage-dev-222053980223-aipstore5b/b7ad/7d08/de96/4d04/83c9/0d2c/6a6d/80e8/2014_039_002-b7ad7d08-de96-4d04-83c9-0d2c6a6d80e8/
```
- _NOTE: at the time of this PR creation, this bag is not yet in inventory and so this will fail_
- successful because full `manifest` was not returned


### Includes new or updated dependencies?
YES | NO

### Changes expectations for external applications?
YES | NO

### What are the relevant tickets?
- Include links to Jira Software and/or Jira Service Management tickets here.

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes