### PR TITLE
IR 228 - resume/retry bulk validation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ pytest-mock = "*"
 ruff = "*"
 setuptools = "*"
 types-requests = "*"
+pytest-reraise = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "554ccd6e6699afe55f667d8b57812b54539d96f1a67293d6493cd480d4206091"
+            "sha256": "0d9559d89dc8a7b2c3a065982e71bca59ba42261d0e0d417b0f03d685bd15699"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,20 +18,20 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:09ee85ba70a88286bba0d1bf5f0460a4b3bde52d162216accfe637b8bfac351b",
-                "sha256:e584d9d33808633e73af3d962e22cf2cea91a38bc5a17577bb25618f8ded504f"
+                "sha256:8b6544eca17e31d1bfd538e5d152b96a68d6c92950352a0cd9679f89d217d53a",
+                "sha256:96898facb164b47859d40a4271007824a0a791c3811a7079ce52459d753d4474"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==1.37.28"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.38.0"
         },
         "botocore": {
             "hashes": [
-                "sha256:69ea327f70f0607d174c4c2b1dcc87327b9c48e413c9d322179172b614b28e03",
-                "sha256:c26b645d7b125bf42ffc1671b862b47500ee658e3a1c95d2438cb689fc85df15"
+                "sha256:ac8997291bcfd28d329a779ceda429fbe9f8950ba051429a37ba93cbda025e94",
+                "sha256:f9d58404796a44746d54c4a9318a8970fb4dbcbdc45aa0e75bf528af4213b6b5"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.37.28"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.38.0"
         },
         "certifi": {
             "hashes": [
@@ -150,61 +150,61 @@
         },
         "duckdb": {
             "hashes": [
-                "sha256:0648d763a36bf058c9dd30ce46b06b7753600101ffb1519e66fa85fbf4c02d91",
-                "sha256:0e26037b138a22f72fe44697b605ccac06e223c108b3f4a3e91e7ffad45ee673",
-                "sha256:11a8a275777b8174a1fdca660689dd0335642b30ae425fe16892f9f9cd285129",
-                "sha256:15d49030d04572540cc1c8ad8a491ce018a590ec995d5d38c8f5f75b6422413e",
-                "sha256:18a3ebb6895e53ddcc9f677625576d85a54236a0fc060927bc356de365c8d382",
-                "sha256:1adecebea8369b289232ec57e0fab87b572bca960acbeff89e8b7c2d202636a3",
-                "sha256:1b6dfefadc455347a2c649d41ebd561b32574b4191508043c9ee81fa0da95485",
-                "sha256:203ebdf401d049135492cc3d49146cfd704d866ee9cc52b18e80a586aceabb69",
-                "sha256:2c3d3f069a114cfb4ebf5e35798953c93491cfb5866cfc57a4921f8b5d38cc05",
-                "sha256:317af7385b4f1d0c90ca029a71ce3d4f9571549c162798d58a0b20ba0a11762e",
-                "sha256:3d03872cd8e4a8b571e21c3628ea9cb1610b6d739ed41c1cee5dae49a23d1886",
-                "sha256:3d75d9fdf5865399f634d824c8d427c7666d1f2c640115178115459fa69b20b0",
-                "sha256:41fca1666d0905e929ede0899a4275d67835a285b98e28fce446e8c3e53cfe8c",
-                "sha256:42d156dacb1fd39b7293ee200d16af2cc9d08e57f7f7b5e800aa35bd265fc41f",
-                "sha256:433406949970f4a8ab5416f62af224d418d3bbafe81585ede77057752c04017e",
-                "sha256:47946714d3aa423782678d37bfface082a9c43d232c44c4b79d70a1137e4c356",
-                "sha256:4e11ccbfd088dbac68dc35f4119fb385a878ca1cce720111c394f513d89a8b5f",
-                "sha256:55c9b4214dd80e6adf73c7224529e0df290426d9fe5b6568dcd004916e690b84",
-                "sha256:577537f3be6b05e28b9844d8a06835764053552c9974e42e0c3a1711fbf59054",
-                "sha256:594dcf9f7637e5db3d8d9e676a95721be5cf9657ffa22b27e19dddd519bca6fb",
-                "sha256:6043d37e289df828fada6245381c3d1b67b71e0245f1b599b6c4c2634318aed2",
-                "sha256:6112711457b6014ac041492bedf8b6a97403666aefa20a4a4f3479db10136501",
-                "sha256:66322686a31a566b4c98f079513b1eba21a7de1d716b5b7d3a55aef8f97ee369",
-                "sha256:6a6ea26a899b05aeaadd23c9182978a266d5cd4f62e4ef7d9f197f889a441a9d",
-                "sha256:6e2f530e8290e4b2d2c341bc709a6a0c9ec7a0e1c7a4679afa7bd4db972fcf12",
-                "sha256:716fa104d5a1a6f81a8bd6febf579cb45c20920cdfbcafd55131bfeef61330f0",
-                "sha256:7928a1f7a0568e3f384dbb2896d33fe96061444033692c8a954ac75a06efbda3",
-                "sha256:7985129c4bc810cb08938043822bb1fc4b67c11f4c1b025527f9c888e0638b6a",
-                "sha256:7a30e6bff4dbe6686ef3ff2d69aa0a4a09ad87b99ddc3933c4d118b1413fda51",
-                "sha256:7c252be2ed07817916342823b271253459932c60d7f7ee4e28f33650552cda24",
-                "sha256:7e587410e05343ffaf9a21bacb6811aad253bd443ab4ff869fdaa645908f47a4",
-                "sha256:832627f11b370d708543a86d18d5eda4eacb7ca51fdc83c74629adfff2ec1bf2",
-                "sha256:8cb84295cafbf2510326f4ae18d401fc2d45b6d4811c43f1b7451a69a0a74f5f",
-                "sha256:922288c3b5933f58bdaac5f0357dada68f472cf5458d64b954509bbbbc11c391",
-                "sha256:97b2c13f4f9290db60c783b93b79ce521a3890ff8d817a6670afb760e030043b",
-                "sha256:99c47ea82df549c284e4e4d8c89a940af4f19c03427f6f42cafeb3c152536bc5",
-                "sha256:a874d242f489bf649e6f03f3132d8d278371a8baf0ce55b48200af0de70d8f1f",
-                "sha256:ab84599120b0f835b67b897a4febcb0326b206201773f0673891378e16f850f5",
-                "sha256:ac5f7c15176b6fb90f1f3bed08a99b9d32f55b58cd3d9d2ed6a1037a8fda2024",
-                "sha256:b0e728ab0415d3e9ff575806304482bf89f39e55df660ab8ed194335b045e5a0",
-                "sha256:b1b26271c22d1265379949b71b1d13a413f8048ea49ed04b3a33f257c384fa7c",
-                "sha256:b26ff415d89860b7013d711fce916f919ad058dbf0a3fc4bcdff5323ec4bbfa0",
-                "sha256:bc9ed3adea35e7e688750e80330b5b93cd430483d68a5f880dac76bedca14c0e",
-                "sha256:be76e55e9a36febcb0c7c7c28b8fae0b33bbcf6a84b3b23eb23e7ee3e65e3394",
-                "sha256:c1b5e4f1ef608b9276fef880d31b84304683f08035b5c177a0848310de37c6e5",
-                "sha256:c1cbb84c65f8ef2fe32f4cbc8c7ed339c3ae6cf3e5814a314fa4b79a8ce9686a",
-                "sha256:d05e5914857b4d93b136de385d81a65165a6c24a6ecf6eee3dcd0017233bff6c",
-                "sha256:d493e051f594175a2a5bdcae5c008d3cc424805e3282292c1204f597880de8ea",
-                "sha256:d4a05d182d1dec1ff4acb53a266b3b8024afcc1ed0d399f5784ff1607a4271e9",
-                "sha256:d8f5066ae9acc6cee22c7a455696511d993bdbfc55bb9466360b073b5c8cba67",
-                "sha256:f8f19f145442dbdfae029b68208fc237816f70b3d25bb77ed31ace79b6059fa5"
+                "sha256:0353f80882c066f7b14451852395b7a360f3d4846a10555c4268eb49144ea11c",
+                "sha256:081110ffbc9d53c9740ef55482c93b97db2f8030d681d1658827d2e94f77da03",
+                "sha256:087713fc5958cae5eb59097856b3deaae0def021660c8f2052ec83fa8345174a",
+                "sha256:0c1a3496695c7220ac83dde02fc1cf174359c8072a6880050c8ae6b5c62a2635",
+                "sha256:14d41f899ce7979e7b3f9097ebce70da5c659db2d81d08c07a72b2b50f869859",
+                "sha256:1e53555dece49201df08645dbfa4510c86440339889667702f936b7d28d39e43",
+                "sha256:2418937adb9d6d0ca823bd385b914495294db27bc2963749d54af6708757f679",
+                "sha256:25ac669180f88fecca20f300b898e191f81aa674d51dde8a328bdeb28a572ab0",
+                "sha256:26e9c349f56f7c99341b5c79bbaff5ba12a5414af0261e79bf1a6a2693f152f6",
+                "sha256:2bd2c6373b8b54474724c2119f6939c4568c428e1d0be5bcb1f4e3d7f1b7c8bb",
+                "sha256:30bece4f58a6c7bb0944a02dd1dc6de435a9daf8668fa31a9fe3a9923b20bd65",
+                "sha256:378ef6a3d1a8b50da5a89376cc0cc6f131102d4a27b4b3adef10b20f7a6ea49f",
+                "sha256:3b451d16c3931fdbc235a12a39217a2faa03fa7c84c8560e65bc9b706e876089",
+                "sha256:446a5db77caeb155bcc0874c162a51f6d023af4aa2563fffbdec555db7402a35",
+                "sha256:53a154dbc074604036a537784ce5d1468edf263745a4363ca06fdb922f0d0a99",
+                "sha256:6507ad2445cd3479853fb6473164b5eb5b22446d283c9892cfbbd0a85c5f361d",
+                "sha256:690885060c4140922ffa2f6935291c6e74ddad0ca2cf33bff66474ce89312ab3",
+                "sha256:6aba3bc0acf4f8d52b94f7746c3b0007b78b517676d482dc516d63f48f967baf",
+                "sha256:6e5e6c333b550903ff11919ed1154c60c9b9d935db51afdb263babe523a8a69e",
+                "sha256:72f688a8b0df7030c5a28ca6072817c1f090979e08d28ee5912dee37c26a7d0c",
+                "sha256:73263f81545c5cb4360fbaf7b22a493e55ddf88fadbe639c43efb7bc8d7554c4",
+                "sha256:85e90a9c5307cf4d9151844e60c80f492618ea6e9b71081020e7d462e071ac8f",
+                "sha256:88916d7f0532dc926bed84b50408c00dcbe6d2097d0de93c3ff647d8d57b4f83",
+                "sha256:890f58855d127c25bc3a53f4c24b27e79391c4468c4fcc99bc10d87b5d4bd1c4",
+                "sha256:8a382782980643f5ee827990b76f079b22f47786509061c0afac28afaa5b8bf5",
+                "sha256:9a5002305cdd4e76c94b61b50abc5e3f4e32c9cb81116960bb4b74acbbc9c6c8",
+                "sha256:a1f96395319c447a31b9477881bd84b4cb8323d6f86f21ceaef355d22dd90623",
+                "sha256:b134a5002757af1ae44a9ae26c2fe963ffa09eb47a62779ce0c5eeb44bfc2f28",
+                "sha256:b1c0c4d737fd2ab9681e4e78b9f361e0a827916a730e84fa91e76dca451b14d5",
+                "sha256:b744f8293ce649d802a9eabbf88e4930d672cf9de7d4fc9af5d14ceaeeec5805",
+                "sha256:b985d13e161c27e8b947af28658d460925bade61cb5d7431b8258a807cc83752",
+                "sha256:c0f86c5e4ab7d4007ca0baa1707486daa38869c43f552a56e9cd2a28d431c2ae",
+                "sha256:c0fc6512d26eac83521938d7de65645ec08b04c2dc7807d4e332590c667e9d78",
+                "sha256:c1fcbc579de8e4fa7e34242fd6f419c1a39520073b1fe0c29ed6e60ed5553f38",
+                "sha256:c8680e81b0c77be9fc968c1dd4cd38395c34b18bb693cbfc7b7742c18221cc9b",
+                "sha256:cdb9999c6a109aa31196cdd22fc58a810a3d35d08181a25d1bf963988e89f0a5",
+                "sha256:cee19d0c5bcb143b851ebd3ffc91e3445c5c3ee3cc0106edd882dd5b4091d5c0",
+                "sha256:d1b374e7e2c474d6cd65fd80a94ff7263baec4be14ea193db4076d54eab408f9",
+                "sha256:d42e7e545d1059e6b73d0f0baa9ae34c90684bfd8c862e70b0d8ab92e01e0e3f",
+                "sha256:d625cc7d2faacfb2fc83ebbe001ae75dda175b3d8dce6a51a71c199ffac3627a",
+                "sha256:d7c33345570ed8c50c9fe340c2767470115cc02d330f25384104cfad1f6e54f5",
+                "sha256:d8bb89e580cb9a3aaf42e4555bf265d3db9446abfb118e32150e1a5dfa4b5b15",
+                "sha256:df8c8a4ec998139b8507213c44c50e24f62a36af1cfded87e8972173dc9f8baf",
+                "sha256:e1aec7102670e59d83512cf47d32a6c77a79df9df0294c5e4d16b6259851e2e9",
+                "sha256:e5c1556775a9ebaa49b5c8d64718f155ac3e05b34a49e9c99443cf105e8b0371",
+                "sha256:f3ce127bcecc723f1c7bddbc57f0526d11128cb05bfd81ffcd5e69e2dd5a1624",
+                "sha256:f3f8e09029ae47d3b904d32a03149ffc938bb3fb8a3048dc7b2d0f2ab50e0f56",
+                "sha256:f745379f44ad302560688855baaed9739c03b37a331338eda6a4ac655e4eb42f",
+                "sha256:fb41f2035a70378b3021f724bb08b047ca4aa475850a3744c442570054af3c52",
+                "sha256:fb9a2c77236fae079185a990434cb9d8432902488ba990235c702fc2692d2dcd",
+                "sha256:fd9c434127fd1575694e1cf19a393bed301f5d6e80b4bcdae80caa368a61a678"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==1.2.1"
+            "version": "==1.2.2"
         },
         "idna": {
             "hashes": [
@@ -224,64 +224,64 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286",
-                "sha256:0d54974f9cf14acf49c60f0f7f4084b6579d24d439453d5fc5805d46a165b542",
-                "sha256:11c43995255eb4127115956495f43e9343736edb7fcdb0d973defd9de14cd84f",
-                "sha256:188dcbca89834cc2e14eb2f106c96d6d46f200fe0200310fc29089657379c58d",
-                "sha256:1974afec0b479e50438fc3648974268f972e2d908ddb6d7fb634598cdb8260a0",
-                "sha256:1cf4e5c6a278d620dee9ddeb487dc6a860f9b199eadeecc567f777daace1e9e7",
-                "sha256:207a2b8441cc8b6a2a78c9ddc64d00d20c303d79fba08c577752f080c4007ee3",
-                "sha256:218f061d2faa73621fa23d6359442b0fc658d5b9a70801373625d958259eaca3",
-                "sha256:2aad3c17ed2ff455b8eaafe06bcdae0062a1db77cb99f4b9cbb5f4ecb13c5146",
-                "sha256:2fa8fa7697ad1646b5c93de1719965844e004fcad23c91228aca1cf0800044a1",
-                "sha256:31504f970f563d99f71a3512d0c01a645b692b12a63630d6aafa0939e52361e6",
-                "sha256:3387dd7232804b341165cedcb90694565a6015433ee076c6754775e85d86f1fc",
-                "sha256:4ba5054787e89c59c593a4169830ab362ac2bee8a969249dc56e5d7d20ff8df9",
-                "sha256:4f92084defa704deadd4e0a5ab1dc52d8ac9e8a8ef617f3fbb853e79b0ea3592",
-                "sha256:65ef3468b53269eb5fdb3a5c09508c032b793da03251d5f8722b1194f1790c00",
-                "sha256:6f527d8fdb0286fd2fd97a2a96c6be17ba4232da346931d967a0630050dfd298",
-                "sha256:7051ee569db5fbac144335e0f3b9c2337e0c8d5c9fee015f259a5bd70772b7e8",
-                "sha256:7716e4a9b7af82c06a2543c53ca476fa0b57e4d760481273e09da04b74ee6ee2",
-                "sha256:79bd5f0a02aa16808fcbc79a9a376a147cc1045f7dfe44c6e7d53fa8b8a79392",
-                "sha256:7a4e84a6283b36632e2a5b56e121961f6542ab886bc9e12f8f9818b3c266bfbb",
-                "sha256:8120575cb4882318c791f839a4fd66161a6fa46f3f0a5e613071aae35b5dd8f8",
-                "sha256:81413336ef121a6ba746892fad881a83351ee3e1e4011f52e97fba79233611fd",
-                "sha256:8146f3550d627252269ac42ae660281d673eb6f8b32f113538e0cc2a9aed42b9",
-                "sha256:879cf3a9a2b53a4672a168c21375166171bc3932b7e21f622201811c43cdd3b0",
-                "sha256:892c10d6a73e0f14935c31229e03325a7b3093fafd6ce0af704be7f894d95687",
-                "sha256:92bda934a791c01d6d9d8e038363c50918ef7c40601552a58ac84c9613a665bc",
-                "sha256:9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f",
-                "sha256:9eeea959168ea555e556b8188da5fa7831e21d91ce031e95ce23747b7609f8a4",
-                "sha256:a0258ad1f44f138b791327961caedffbf9612bfa504ab9597157806faa95194a",
-                "sha256:a761ba0fa886a7bb33c6c8f6f20213735cb19642c580a931c625ee377ee8bd39",
-                "sha256:a7b9084668aa0f64e64bd00d27ba5146ef1c3a8835f3bd912e7a9e01326804c4",
-                "sha256:a84eda42bd12edc36eb5b53bbcc9b406820d3353f1994b6cfe453a33ff101775",
-                "sha256:ab2939cd5bec30a7430cbdb2287b63151b77cf9624de0532d629c9a1c59b1d5c",
-                "sha256:ac0280f1ba4a4bfff363a99a6aceed4f8e123f8a9b234c89140f5e894e452ecd",
-                "sha256:adf8c1d66f432ce577d0197dceaac2ac00c0759f573f28516246351c58a85020",
-                "sha256:b4adfbbc64014976d2f91084915ca4e626fbf2057fb81af209c1a6d776d23e3d",
-                "sha256:bb649f8b207ab07caebba230d851b579a3c8711a851d29efe15008e31bb4de24",
-                "sha256:bce43e386c16898b91e162e5baaad90c4b06f9dcbe36282490032cec98dc8ae7",
-                "sha256:bd3ad3b0a40e713fc68f99ecfd07124195333f1e689387c180813f0e94309d6f",
-                "sha256:c3f7ac96b16955634e223b579a3e5798df59007ca43e8d451a0e6a50f6bfdfba",
-                "sha256:cf28633d64294969c019c6df4ff37f5698e8326db68cc2b66576a51fad634880",
-                "sha256:d0f35b19894a9e08639fd60a1ec1978cb7f5f7f1eace62f38dd36be8aecdef4d",
-                "sha256:db1f1c22173ac1c58db249ae48aa7ead29f534b9a948bc56828337aa84a32ed6",
-                "sha256:dbe512c511956b893d2dacd007d955a3f03d555ae05cfa3ff1c1ff6df8851854",
-                "sha256:df2f57871a96bbc1b69733cd4c51dc33bea66146b8c63cacbfed73eec0883017",
-                "sha256:e2f085ce2e813a50dfd0e01fbfc0c12bbe5d2063d99f8b29da30e544fb6483b8",
-                "sha256:e642d86b8f956098b564a45e6f6ce68a22c2c97a04f5acd3f221f57b8cb850ae",
-                "sha256:e9e0a277bb2eb5d8a7407e14688b85fd8ad628ee4e0c7930415687b6564207a4",
-                "sha256:ea2bb7e2ae9e37d96835b3576a4fa4b3a97592fbea8ef7c3587078b0068b8f09",
-                "sha256:ee4d528022f4c5ff67332469e10efe06a267e32f4067dc76bb7e2cddf3cd25ff",
-                "sha256:f05d4198c1bacc9124018109c5fba2f3201dbe7ab6e92ff100494f236209c960",
-                "sha256:f34dc300df798742b3d06515aa2a0aee20941c13579d7a2f2e10af01ae4901ee",
-                "sha256:f4162988a360a29af158aeb4a2f4f09ffed6a969c9776f8f3bdee9b06a8ab7e5",
-                "sha256:f486038e44caa08dbd97275a9a35a283a8f1d2f0ee60ac260a1790e76660833c",
-                "sha256:f7de08cbe5551911886d1ab60de58448c6df0f67d9feb7d1fb21e9875ef95e91"
+                "sha256:0255732338c4fdd00996c0421884ea8a3651eea555c3a56b84892b66f696eb70",
+                "sha256:02f226baeefa68f7d579e213d0f3493496397d8f1cff5e2b222af274c86a552a",
+                "sha256:059b51b658f4414fff78c6d7b1b4e18283ab5fa56d270ff212d5ba0c561846f4",
+                "sha256:0bcb1d057b7571334139129b7f941588f69ce7c4ed15a9d6162b2ea54ded700c",
+                "sha256:0cd48122a6b7eab8f06404805b1bd5856200e3ed6f8a1b9a194f9d9054631beb",
+                "sha256:19f4718c9012e3baea91a7dba661dcab2451cda2550678dc30d53acb91a7290f",
+                "sha256:1a161c2c79ab30fe4501d5a2bbfe8b162490757cf90b7f05be8b80bc02f7bb8e",
+                "sha256:1f4a922da1729f4c40932b2af4fe84909c7a6e167e6e99f71838ce3a29f3fe26",
+                "sha256:261a1ef047751bb02f29dfe337230b5882b54521ca121fc7f62668133cb119c9",
+                "sha256:262d23f383170f99cd9191a7c85b9a50970fe9069b2f8ab5d786eca8a675d60b",
+                "sha256:2ba321813a00e508d5421104464510cc962a6f791aa2fca1c97b1e65027da80d",
+                "sha256:2c1a1c6ccce4022383583a6ded7bbcda22fc635eb4eb1e0a053336425ed36dfa",
+                "sha256:352d330048c055ea6db701130abc48a21bec690a8d38f8284e00fab256dc1376",
+                "sha256:369e0d4647c17c9363244f3468f2227d557a74b6781cb62ce57cf3ef5cc7c610",
+                "sha256:36ab5b23915887543441efd0417e6a3baa08634308894316f446027611b53bf1",
+                "sha256:37e32e985f03c06206582a7323ef926b4e78bdaa6915095ef08070471865b906",
+                "sha256:3a801fef99668f309b88640e28d261991bfad9617c27beda4a3aec4f217ea073",
+                "sha256:3d14b17b9be5f9c9301f43d2e2a4886a33b53f4e6fdf9ca2f4cc60aeeee76372",
+                "sha256:422cc684f17bc963da5f59a31530b3936f57c95a29743056ef7a7903a5dbdf88",
+                "sha256:4520caa3807c1ceb005d125a75e715567806fed67e315cea619d5ec6e75a4191",
+                "sha256:47834cde750d3c9f4e52c6ca28a7361859fcaf52695c7dc3cc1a720b8922683e",
+                "sha256:47f9ed103af0bc63182609044b0490747e03bd20a67e391192dde119bf43d52f",
+                "sha256:498815b96f67dc347e03b719ef49c772589fb74b8ee9ea2c37feae915ad6ebda",
+                "sha256:54088a5a147ab71a8e7fdfd8c3601972751ded0739c6b696ad9cb0343e21ab73",
+                "sha256:55f09e00d4dccd76b179c0f18a44f041e5332fd0e022886ba1c0bbf3ea4a18d0",
+                "sha256:5a0ac90e46fdb5649ab6369d1ab6104bfe5854ab19b645bf5cda0127a13034ae",
+                "sha256:6411f744f7f20081b1b4e7112e0f4c9c5b08f94b9f086e6f0adf3645f85d3a4d",
+                "sha256:6413d48a9be53e183eb06495d8e3b006ef8f87c324af68241bbe7a39e8ff54c3",
+                "sha256:7451f92eddf8503c9b8aa4fe6aa7e87fd51a29c2cfc5f7dbd72efde6c65acf57",
+                "sha256:8b4c0773b6ada798f51f0f8e30c054d32304ccc6e9c5d93d46cb26f3d385ab19",
+                "sha256:8dfa94b6a4374e7851bbb6f35e6ded2120b752b063e6acdd3157e4d2bb922eba",
+                "sha256:97c8425d4e26437e65e1d189d22dff4a079b747ff9c2788057bfb8114ce1e133",
+                "sha256:9d75f338f5f79ee23548b03d801d28a505198297534f62416391857ea0479571",
+                "sha256:9de6832228f617c9ef45d948ec1cd8949c482238d68b2477e6f642c33a7b0a54",
+                "sha256:a4cbdef3ddf777423060c6f81b5694bad2dc9675f110c4b2a60dc0181543fac7",
+                "sha256:a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291",
+                "sha256:aa70fdbdc3b169d69e8c59e65c07a1c9351ceb438e627f0fdcd471015cd956be",
+                "sha256:abe38cd8381245a7f49967a6010e77dbf3680bd3627c0fe4362dd693b404c7f8",
+                "sha256:b13f04968b46ad705f7c8a80122a42ae8f620536ea38cf4bdd374302926424dd",
+                "sha256:b4ea7e1cff6784e58fe281ce7e7f05036b3e1c89c6f922a6bfbc0a7e8768adbe",
+                "sha256:b6f91524d31b34f4a5fee24f5bc16dcd1491b668798b6d85585d836c1e633a6a",
+                "sha256:c26843fd58f65da9491165072da2cccc372530681de481ef670dcc8e27cfb066",
+                "sha256:c42365005c7a6c42436a54d28c43fe0e01ca11eb2ac3cefe796c25a5f98e5e9b",
+                "sha256:c8b82a55ef86a2d8e81b63da85e55f5537d2157165be1cb2ce7cfa57b6aef38b",
+                "sha256:ced69262a8278547e63409b2653b372bf4baff0870c57efa76c5703fd6543282",
+                "sha256:d2e3bdadaba0e040d1e7ab39db73e0afe2c74ae277f5614dad53eadbecbbb169",
+                "sha256:d403c84991b5ad291d3809bace5e85f4bbf44a04bdc9a88ed2bb1807b3360bb8",
+                "sha256:d7543263084a85fbc09c704b515395398d31d6395518446237eac219eab9e55e",
+                "sha256:d8882a829fd779f0f43998e931c466802a77ca1ee0fe25a3abe50278616b1471",
+                "sha256:e4f0b035d9d0ed519c813ee23e0a733db81ec37d2e9503afbb6e54ccfdee0fa7",
+                "sha256:e8b025c351b9f0e8b5436cf28a07fa4ac0204d67b38f01433ac7f9b870fa38c6",
+                "sha256:eb7fd5b184e5d277afa9ec0ad5e4eb562ecff541e7f60e69ee69c8d59e9aeaba",
+                "sha256:ec31367fd6a255dc8de4772bd1658c3e926d8e860a0b6e922b615e532d320ddc",
+                "sha256:ee461a4eaab4f165b68780a6a1af95fb23a29932be7569b9fab666c407969051",
+                "sha256:f5045039100ed58fa817a6227a356240ea1b9a1bc141018864c306c1a16d4175"
             ],
             "markers": "python_version >= '3.12'",
-            "version": "==2.2.4"
+            "version": "==2.2.5"
         },
         "pandas": {
             "hashes": [
@@ -337,7 +337,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -358,27 +358,27 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679",
-                "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d"
+                "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18",
+                "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.11.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.12.0"
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:60b016d0772789454dc55a284a6a44212044d4a16d9f8448725effee97aaf7f6",
-                "sha256:f9041b7054a7cf12d41eadabe6458ce7c6d6eea7a97cfe1b760b6692e9562cf0"
+                "sha256:759e019c41551a21519a95e6cef6d91fb4af1054761923dadaee2e6eca9c02c7",
+                "sha256:e99390e3f217d13ddcbaeaed08789f1ca614d663b345b9da42e35ad6b60d696a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2.25.1"
+            "version": "==2.26.1"
         },
         "six": {
             "hashes": [
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
         },
         "tzdata": {
@@ -391,11 +391,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
-                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
+                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
+                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         }
     },
     "develop": {
@@ -441,19 +441,19 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:a27cb833f4cfb1795acf04c6106297a552e66cd612c208618542d4abe5ce26bd",
-                "sha256:f859263ce76cb33a4c79dea545cd447588ca23a1fd09083c16f8e58605f89515"
+                "sha256:b0463ecb8a96586096ede407bc2b947882d8b7ea348a048db7622f6e1e00b931",
+                "sha256:fa17293b6ff1bb6e1ba371fe1975598786bf3c5c00f2cb6cb5568008ca80293b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.28"
+            "version": "==1.38.0"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:16c4e5976cb83b863884720350e245ddde73bd39cfe2c948d5ac57c70aaec89e",
-                "sha256:adb5376af3f142b01f0f5dd39aa1a155ecc38fd0a0fd070db96ac1c7b8cc16e9"
+                "sha256:6aae362f71830d553a4090267de7cabda93ac4c813c3ccc417205f0afdb8da62",
+                "sha256:c1a59c3b40925710ed351f288cde8e92833b0c39e0182e6a6520db2fbfbb54fa"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.28"
+            "version": "==1.38.0"
         },
         "certifi": {
             "hashes": [
@@ -698,11 +698,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:c98b4322da415a8e5a70ff6e51fbc2d2932c015532d77e9f8537b4ba7813b150",
-                "sha256:d40dfe3142a1421d8518e3d3985ef5ac42890683e32306ad614a29490abeb6bf"
+                "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8",
+                "sha256:5f34248f54136beed1a7ba6a6b5c4b6cf21ff495aac7c359e1ef831ae3b8ab25"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.6.9"
+            "version": "==2.6.10"
         },
         "idna": {
             "hashes": [
@@ -794,18 +794,18 @@
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:4df0975256132ab452896b9d36571866a816157d519cf12c661795b2906e2e9c",
-                "sha256:8afd8d64be352652bc888ed81750788bebabd2b6e8ee6fe9be00ff25228df39b"
+                "sha256:5cd9449df0ef6cf89e00e6fc9130a0ab641f703a23ab1d2146c394da058e8282",
+                "sha256:f8fe586e45123ffcd305a0c30847128f3931d888649e2b4c5a52f412183c840a"
             ],
-            "version": "==1.37.24"
+            "version": "==1.38.0"
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
-                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
         },
         "nodeenv": {
             "hashes": [
@@ -817,72 +817,72 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286",
-                "sha256:0d54974f9cf14acf49c60f0f7f4084b6579d24d439453d5fc5805d46a165b542",
-                "sha256:11c43995255eb4127115956495f43e9343736edb7fcdb0d973defd9de14cd84f",
-                "sha256:188dcbca89834cc2e14eb2f106c96d6d46f200fe0200310fc29089657379c58d",
-                "sha256:1974afec0b479e50438fc3648974268f972e2d908ddb6d7fb634598cdb8260a0",
-                "sha256:1cf4e5c6a278d620dee9ddeb487dc6a860f9b199eadeecc567f777daace1e9e7",
-                "sha256:207a2b8441cc8b6a2a78c9ddc64d00d20c303d79fba08c577752f080c4007ee3",
-                "sha256:218f061d2faa73621fa23d6359442b0fc658d5b9a70801373625d958259eaca3",
-                "sha256:2aad3c17ed2ff455b8eaafe06bcdae0062a1db77cb99f4b9cbb5f4ecb13c5146",
-                "sha256:2fa8fa7697ad1646b5c93de1719965844e004fcad23c91228aca1cf0800044a1",
-                "sha256:31504f970f563d99f71a3512d0c01a645b692b12a63630d6aafa0939e52361e6",
-                "sha256:3387dd7232804b341165cedcb90694565a6015433ee076c6754775e85d86f1fc",
-                "sha256:4ba5054787e89c59c593a4169830ab362ac2bee8a969249dc56e5d7d20ff8df9",
-                "sha256:4f92084defa704deadd4e0a5ab1dc52d8ac9e8a8ef617f3fbb853e79b0ea3592",
-                "sha256:65ef3468b53269eb5fdb3a5c09508c032b793da03251d5f8722b1194f1790c00",
-                "sha256:6f527d8fdb0286fd2fd97a2a96c6be17ba4232da346931d967a0630050dfd298",
-                "sha256:7051ee569db5fbac144335e0f3b9c2337e0c8d5c9fee015f259a5bd70772b7e8",
-                "sha256:7716e4a9b7af82c06a2543c53ca476fa0b57e4d760481273e09da04b74ee6ee2",
-                "sha256:79bd5f0a02aa16808fcbc79a9a376a147cc1045f7dfe44c6e7d53fa8b8a79392",
-                "sha256:7a4e84a6283b36632e2a5b56e121961f6542ab886bc9e12f8f9818b3c266bfbb",
-                "sha256:8120575cb4882318c791f839a4fd66161a6fa46f3f0a5e613071aae35b5dd8f8",
-                "sha256:81413336ef121a6ba746892fad881a83351ee3e1e4011f52e97fba79233611fd",
-                "sha256:8146f3550d627252269ac42ae660281d673eb6f8b32f113538e0cc2a9aed42b9",
-                "sha256:879cf3a9a2b53a4672a168c21375166171bc3932b7e21f622201811c43cdd3b0",
-                "sha256:892c10d6a73e0f14935c31229e03325a7b3093fafd6ce0af704be7f894d95687",
-                "sha256:92bda934a791c01d6d9d8e038363c50918ef7c40601552a58ac84c9613a665bc",
-                "sha256:9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f",
-                "sha256:9eeea959168ea555e556b8188da5fa7831e21d91ce031e95ce23747b7609f8a4",
-                "sha256:a0258ad1f44f138b791327961caedffbf9612bfa504ab9597157806faa95194a",
-                "sha256:a761ba0fa886a7bb33c6c8f6f20213735cb19642c580a931c625ee377ee8bd39",
-                "sha256:a7b9084668aa0f64e64bd00d27ba5146ef1c3a8835f3bd912e7a9e01326804c4",
-                "sha256:a84eda42bd12edc36eb5b53bbcc9b406820d3353f1994b6cfe453a33ff101775",
-                "sha256:ab2939cd5bec30a7430cbdb2287b63151b77cf9624de0532d629c9a1c59b1d5c",
-                "sha256:ac0280f1ba4a4bfff363a99a6aceed4f8e123f8a9b234c89140f5e894e452ecd",
-                "sha256:adf8c1d66f432ce577d0197dceaac2ac00c0759f573f28516246351c58a85020",
-                "sha256:b4adfbbc64014976d2f91084915ca4e626fbf2057fb81af209c1a6d776d23e3d",
-                "sha256:bb649f8b207ab07caebba230d851b579a3c8711a851d29efe15008e31bb4de24",
-                "sha256:bce43e386c16898b91e162e5baaad90c4b06f9dcbe36282490032cec98dc8ae7",
-                "sha256:bd3ad3b0a40e713fc68f99ecfd07124195333f1e689387c180813f0e94309d6f",
-                "sha256:c3f7ac96b16955634e223b579a3e5798df59007ca43e8d451a0e6a50f6bfdfba",
-                "sha256:cf28633d64294969c019c6df4ff37f5698e8326db68cc2b66576a51fad634880",
-                "sha256:d0f35b19894a9e08639fd60a1ec1978cb7f5f7f1eace62f38dd36be8aecdef4d",
-                "sha256:db1f1c22173ac1c58db249ae48aa7ead29f534b9a948bc56828337aa84a32ed6",
-                "sha256:dbe512c511956b893d2dacd007d955a3f03d555ae05cfa3ff1c1ff6df8851854",
-                "sha256:df2f57871a96bbc1b69733cd4c51dc33bea66146b8c63cacbfed73eec0883017",
-                "sha256:e2f085ce2e813a50dfd0e01fbfc0c12bbe5d2063d99f8b29da30e544fb6483b8",
-                "sha256:e642d86b8f956098b564a45e6f6ce68a22c2c97a04f5acd3f221f57b8cb850ae",
-                "sha256:e9e0a277bb2eb5d8a7407e14688b85fd8ad628ee4e0c7930415687b6564207a4",
-                "sha256:ea2bb7e2ae9e37d96835b3576a4fa4b3a97592fbea8ef7c3587078b0068b8f09",
-                "sha256:ee4d528022f4c5ff67332469e10efe06a267e32f4067dc76bb7e2cddf3cd25ff",
-                "sha256:f05d4198c1bacc9124018109c5fba2f3201dbe7ab6e92ff100494f236209c960",
-                "sha256:f34dc300df798742b3d06515aa2a0aee20941c13579d7a2f2e10af01ae4901ee",
-                "sha256:f4162988a360a29af158aeb4a2f4f09ffed6a969c9776f8f3bdee9b06a8ab7e5",
-                "sha256:f486038e44caa08dbd97275a9a35a283a8f1d2f0ee60ac260a1790e76660833c",
-                "sha256:f7de08cbe5551911886d1ab60de58448c6df0f67d9feb7d1fb21e9875ef95e91"
+                "sha256:0255732338c4fdd00996c0421884ea8a3651eea555c3a56b84892b66f696eb70",
+                "sha256:02f226baeefa68f7d579e213d0f3493496397d8f1cff5e2b222af274c86a552a",
+                "sha256:059b51b658f4414fff78c6d7b1b4e18283ab5fa56d270ff212d5ba0c561846f4",
+                "sha256:0bcb1d057b7571334139129b7f941588f69ce7c4ed15a9d6162b2ea54ded700c",
+                "sha256:0cd48122a6b7eab8f06404805b1bd5856200e3ed6f8a1b9a194f9d9054631beb",
+                "sha256:19f4718c9012e3baea91a7dba661dcab2451cda2550678dc30d53acb91a7290f",
+                "sha256:1a161c2c79ab30fe4501d5a2bbfe8b162490757cf90b7f05be8b80bc02f7bb8e",
+                "sha256:1f4a922da1729f4c40932b2af4fe84909c7a6e167e6e99f71838ce3a29f3fe26",
+                "sha256:261a1ef047751bb02f29dfe337230b5882b54521ca121fc7f62668133cb119c9",
+                "sha256:262d23f383170f99cd9191a7c85b9a50970fe9069b2f8ab5d786eca8a675d60b",
+                "sha256:2ba321813a00e508d5421104464510cc962a6f791aa2fca1c97b1e65027da80d",
+                "sha256:2c1a1c6ccce4022383583a6ded7bbcda22fc635eb4eb1e0a053336425ed36dfa",
+                "sha256:352d330048c055ea6db701130abc48a21bec690a8d38f8284e00fab256dc1376",
+                "sha256:369e0d4647c17c9363244f3468f2227d557a74b6781cb62ce57cf3ef5cc7c610",
+                "sha256:36ab5b23915887543441efd0417e6a3baa08634308894316f446027611b53bf1",
+                "sha256:37e32e985f03c06206582a7323ef926b4e78bdaa6915095ef08070471865b906",
+                "sha256:3a801fef99668f309b88640e28d261991bfad9617c27beda4a3aec4f217ea073",
+                "sha256:3d14b17b9be5f9c9301f43d2e2a4886a33b53f4e6fdf9ca2f4cc60aeeee76372",
+                "sha256:422cc684f17bc963da5f59a31530b3936f57c95a29743056ef7a7903a5dbdf88",
+                "sha256:4520caa3807c1ceb005d125a75e715567806fed67e315cea619d5ec6e75a4191",
+                "sha256:47834cde750d3c9f4e52c6ca28a7361859fcaf52695c7dc3cc1a720b8922683e",
+                "sha256:47f9ed103af0bc63182609044b0490747e03bd20a67e391192dde119bf43d52f",
+                "sha256:498815b96f67dc347e03b719ef49c772589fb74b8ee9ea2c37feae915ad6ebda",
+                "sha256:54088a5a147ab71a8e7fdfd8c3601972751ded0739c6b696ad9cb0343e21ab73",
+                "sha256:55f09e00d4dccd76b179c0f18a44f041e5332fd0e022886ba1c0bbf3ea4a18d0",
+                "sha256:5a0ac90e46fdb5649ab6369d1ab6104bfe5854ab19b645bf5cda0127a13034ae",
+                "sha256:6411f744f7f20081b1b4e7112e0f4c9c5b08f94b9f086e6f0adf3645f85d3a4d",
+                "sha256:6413d48a9be53e183eb06495d8e3b006ef8f87c324af68241bbe7a39e8ff54c3",
+                "sha256:7451f92eddf8503c9b8aa4fe6aa7e87fd51a29c2cfc5f7dbd72efde6c65acf57",
+                "sha256:8b4c0773b6ada798f51f0f8e30c054d32304ccc6e9c5d93d46cb26f3d385ab19",
+                "sha256:8dfa94b6a4374e7851bbb6f35e6ded2120b752b063e6acdd3157e4d2bb922eba",
+                "sha256:97c8425d4e26437e65e1d189d22dff4a079b747ff9c2788057bfb8114ce1e133",
+                "sha256:9d75f338f5f79ee23548b03d801d28a505198297534f62416391857ea0479571",
+                "sha256:9de6832228f617c9ef45d948ec1cd8949c482238d68b2477e6f642c33a7b0a54",
+                "sha256:a4cbdef3ddf777423060c6f81b5694bad2dc9675f110c4b2a60dc0181543fac7",
+                "sha256:a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291",
+                "sha256:aa70fdbdc3b169d69e8c59e65c07a1c9351ceb438e627f0fdcd471015cd956be",
+                "sha256:abe38cd8381245a7f49967a6010e77dbf3680bd3627c0fe4362dd693b404c7f8",
+                "sha256:b13f04968b46ad705f7c8a80122a42ae8f620536ea38cf4bdd374302926424dd",
+                "sha256:b4ea7e1cff6784e58fe281ce7e7f05036b3e1c89c6f922a6bfbc0a7e8768adbe",
+                "sha256:b6f91524d31b34f4a5fee24f5bc16dcd1491b668798b6d85585d836c1e633a6a",
+                "sha256:c26843fd58f65da9491165072da2cccc372530681de481ef670dcc8e27cfb066",
+                "sha256:c42365005c7a6c42436a54d28c43fe0e01ca11eb2ac3cefe796c25a5f98e5e9b",
+                "sha256:c8b82a55ef86a2d8e81b63da85e55f5537d2157165be1cb2ce7cfa57b6aef38b",
+                "sha256:ced69262a8278547e63409b2653b372bf4baff0870c57efa76c5703fd6543282",
+                "sha256:d2e3bdadaba0e040d1e7ab39db73e0afe2c74ae277f5614dad53eadbecbbb169",
+                "sha256:d403c84991b5ad291d3809bace5e85f4bbf44a04bdc9a88ed2bb1807b3360bb8",
+                "sha256:d7543263084a85fbc09c704b515395398d31d6395518446237eac219eab9e55e",
+                "sha256:d8882a829fd779f0f43998e931c466802a77ca1ee0fe25a3abe50278616b1471",
+                "sha256:e4f0b035d9d0ed519c813ee23e0a733db81ec37d2e9503afbb6e54ccfdee0fa7",
+                "sha256:e8b025c351b9f0e8b5436cf28a07fa4ac0204d67b38f01433ac7f9b870fa38c6",
+                "sha256:eb7fd5b184e5d277afa9ec0ad5e4eb562ecff541e7f60e69ee69c8d59e9aeaba",
+                "sha256:ec31367fd6a255dc8de4772bd1658c3e926d8e860a0b6e922b615e532d320ddc",
+                "sha256:ee461a4eaab4f165b68780a6a1af95fb23a29932be7569b9fab666c407969051",
+                "sha256:f5045039100ed58fa817a6227a356240ea1b9a1bc141018864c306c1a16d4175"
             ],
             "markers": "python_version >= '3.12'",
-            "version": "==2.2.4"
+            "version": "==2.2.5"
         },
         "packaging": {
             "hashes": [
-                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
-                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.2"
+            "version": "==25.0"
         },
         "pandas-stubs": {
             "hashes": [
@@ -944,11 +944,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab",
-                "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198"
+                "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07",
+                "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.0.50"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.51"
         },
         "ptyprocess": {
             "hashes": [
@@ -989,6 +989,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==3.14.0"
+        },
+        "pytest-reraise": {
+            "hashes": [
+                "sha256:5ab59bd0e2028be095289e6dfc9e36cc0b56936465278f3223e81bea0f2d1c70",
+                "sha256:c22430d33b2cc18905959d7af28978e371113fcc6ef67b5fec95efcd80b88c16"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.6.1' and python_full_version < '4.0.0'",
+            "version": "==2.1.2"
         },
         "pyyaml": {
             "hashes": [
@@ -1060,37 +1069,37 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:0e9365a7dff9b93af933dab8aebce53b72d8f815e131796268709890b4a83270",
-                "sha256:126b1bf13154aa18ae2d6c3c5efe144ec14b97c60844cfa6eb960c2a05188222",
-                "sha256:193e6fac6eb60cc97b9f728e953c21cc38a20077ed64f912e9d62b97487f3f2d",
-                "sha256:3f171605f65f4fc49c87f41b456e882cd0c89e4ac9d58e149a2b07930e1d466f",
-                "sha256:51a6494209cacca79e121e9b244dc30d3414dac8cc5afb93f852173a2ecfc906",
-                "sha256:5a9fa1c69c7815e39fcfb3646bbfd7f528fa8e2d4bebdcf4c2bd0fa037a255fb",
-                "sha256:5d94bb1cc2fc94a769b0eb975344f1b1f3d294da1da9ddbb5a77665feb3a3019",
-                "sha256:7a37ca937e307ea18156e775a6ac6e02f34b99e8c23fe63c1996185a4efe0751",
-                "sha256:7af4e5f69b7c138be8dcffa5b4a061bf6ba6a3301f632a6bce25d45daff9bc99",
-                "sha256:8c1747d903447d45ca3d40c794d1a56458c51e5cc1bc77b7b64bd2cf0b1626cc",
-                "sha256:995071203d0fe2183fc7a268766fd7603afb9996785f086b0d76edee8755c896",
-                "sha256:d435db6b9b93d02934cf61ef332e66af82da6d8c69aefdea5994c89997c7a0fc",
-                "sha256:d9f4a761ecbde448a2d3e12fb398647c7f0bf526dbc354a643ec505965824ed2",
-                "sha256:e8806daaf9dfa881a0ed603f8a0e364e4f11b6ed461b56cae2b1c0cab0645304",
-                "sha256:ebf99ea9af918878e6ce42098981fc8c1db3850fef2f1ada69fb1dcdb0f8e79e",
-                "sha256:edad2eac42279df12e176564a23fc6f4aaeeb09abba840627780b1bb11a9d223",
-                "sha256:f103a848be9ff379fc19b5d656c1f911d0a0b4e3e0424f9532ececf319a4296e",
-                "sha256:f45bd2fb1a56a5a85fae3b95add03fb185a0b30cf47f5edc92aa0355ca1d7407"
+                "sha256:01c63ba219514271cee955cd0adc26a4083df1956d57847978383b0e50ffd7d2",
+                "sha256:15adac20ef2ca296dd3d8e2bedc6202ea6de81c091a74661c3666e5c4c223ff6",
+                "sha256:1d8f782286c5ff562e4e00344f954b9320026d8e3fae2ba9e6948443fafd9ffc",
+                "sha256:26a4b9a4e1439f7d0a091c6763a100cef8fbdc10d68593df6f3cfa5abdd9246e",
+                "sha256:3567ba0d07fb170b1b48d944715e3294b77f5b7679e8ba258199a250383ccb79",
+                "sha256:45b2e1d6c0eed89c248d024ea95074d0e09988d8e7b1dad8d3ab9a67017a5b03",
+                "sha256:4dd6b09e98144ad7aec026f5588e493c65057d1b387dd937d7787baa531d9bc2",
+                "sha256:5151a871554be3036cd6e51d0ec6eef56334d74dfe1702de717a995ee3d5b287",
+                "sha256:63c5d4e30d9d0de7fedbfb3e9e20d134b73a30c1e74b596f40f0629d5c28a193",
+                "sha256:77cda2dfbac1ab73aef5e514c4cbfc4ec1fbef4b84a44c736cc26f61b3814cd9",
+                "sha256:9bc583628e1096148011a5d51ff3c836f51899e61112e03e5f2b1573a9b726de",
+                "sha256:b5edf270223dd622218256569636dc3e708c2cb989242262fe378609eccf1308",
+                "sha256:bd40de4115b2ec4850302f1a1d8067f42e70b4990b68838ccb9ccd9f110c5e8b",
+                "sha256:bec8bcc3ac228a45ccc811e45f7eb61b950dbf4cf31a67fa89352574b01c7d79",
+                "sha256:cce85721d09c51f3b782c331b0abd07e9d7d5f775840379c640606d3159cae0e",
+                "sha256:d84dcbe74cf9356d1bdb4a78cf74fd47c740bf7bdeb7529068f69b08272239a1",
+                "sha256:f2959049faeb5ba5e3b378709e9d1bf0cab06528b306b9dd6ebd2a312127964a",
+                "sha256:f55844e818206a9dd31ff27f91385afb538067e2dc0beb05f82c293ab84f7d55"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.4"
+            "version": "==0.11.6"
         },
         "setuptools": {
             "hashes": [
-                "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54",
-                "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"
+                "sha256:9828422e7541213b0aacb6e10bbf9dd8febeaa45a48570e09b6d100e063fc9f9",
+                "sha256:b9ab3a104bedb292323f53797b00864e10e434a3ab3906813a7169e4745b912a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==78.1.0"
+            "version": "==79.0.0"
         },
         "stack-data": {
             "hashes": [
@@ -1109,11 +1118,11 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:7bcd649aedca3c41007ca5757096d3b3bdb454b73ca66970ddae6c2c2f541c8c",
-                "sha256:e11298750c99647f7f3b98d6d6d648790096cd32d445fd0d49a6041a63336c9a"
+                "sha256:176d320a26990efc057d4bf71396e05be027c142252ac48cc0d87aaea0704280",
+                "sha256:aca96f889b3745c0e74f42f08f277fed3bf6e9baa2cf9b06a36f78d77720e504"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.25.7"
+            "version": "==0.26.1"
         },
         "types-pytz": {
             "hashes": [
@@ -1134,27 +1143,27 @@
         },
         "types-s3transfer": {
             "hashes": [
-                "sha256:05fde593c84270f19fd053f0b1e08f5a057d7c5f036b9884e68fb8cd3041ac30",
-                "sha256:2a76d92c07d4a3cb469e5343b2e7560e0b8078b2e03696a65407b8c44c861b61"
+                "sha256:101bbc5b7f00b71512374df881f480fc6bf63c948b5098ab024bf3370fbfb0e8",
+                "sha256:f8f59201481e904362873bf0be3267f259d60ad946ebdfcb847d092a1fa26f98"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.11.4"
+            "version": "==0.12.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69",
-                "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff"
+                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
+                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.13.1"
+            "version": "==4.13.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
-                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
+                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
+                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "virtualenv": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -14,6 +14,60 @@ AWS Lambda to validate a [Bagit](https://www.ietf.org/rfc/rfc8493.txt) bag store
 
 See [instructions for running via AWS SAM CLI here](tests/sam/README.md).
 
+## Lambda Request / Response Payloads
+
+This AWS Lambda is primarily invoked via a `POST` HTTP request.  The following outline the request and response payloads. 
+
+### Request Payload
+
+- `action`
+  - action for the lambda to perform
+  - allowed values: `[validate, ping]`
+- `aip_uuid`
+  - UUID of the AIP to validate
+- `challenge_secret`
+  - lightweight authorization string known by requester and Lambda
+- `verbose`
+  - boolean for verbose logs
+
+#### Example: `validate` by passing AIP UUID
+```json
+{
+    "action":"validate",
+    "aip_uuid":"29d47878-a513-475a-bd1d-ffabd1026e24",
+    "challenge_secret":"totally-local-s3-bagit-validating",
+    "verbose":false
+}
+```
+
+#### Example: `validate` by passing AIP S3 URI
+```json
+{
+    "action":"validate",
+    "aip_s3_uri":"s3://my-aips-bucket/29d4/7878/a513/475a/bd1d/ffab/d102/6e24/testdev_aipstore4-29d47878-a513-475a-bd1d-ffabd1026e24",
+    "challenge_secret":"totally-local-s3-bagit-validating",
+    "verbose":false
+}
+```
+
+### Response Payload
+
+#### Example: Valid AIP
+
+```json
+{
+    "bucket": "cdps-storage-dev-222053980223-aipstore4b",
+    "aip_uuid": "29d47878-a513-475a-bd1d-ffabd1026e24",
+    "aip_s3_uri": "s3://my-aips-bucket/29d4/7878/a513/475a/bd1d/ffab/d102/6e24/testdev_aipstore4-29d47878-a513-475a-bd1d-ffabd1026e24",
+    "valid": true,
+    "elapsed": 2.1,
+    "error": null,
+    "error_details": null
+}
+```
+- `bucket`, `aip_uuid`, and `aip_s3_uri` are always returned, regardless of UUID or S3 URI that was provided as input for validation
+- `error` and `error_details` are null when the AIP is valid, otherwise they contain all known validation error information
+
 ## Command Line Interface (CLI)
 
 This application includes a CLI that is designed to invoke the deployed AWS Lambda.  This supports running AIP validation from a command line context, while still utilizing all the wiring and permissions of the deployed lambda.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ Usage: -c bulk-validate [OPTIONS]
 Options:
   -i, --input-csv-filepath TEXT   Filepath of CSV with AIP UUIDs or S3 URIs to
                                   be validated.  [required]
-  -o, --output-csv-filepath TEXT  Filepath of CSV for validation results.
-  -d, --details                   Return full AIP validation details as JSON
-                                  to stdout instead of 'OK'.
+  -o, --output-csv-filepath TEXT  Filepath of CSV for validation results.  If
+                                  file already exists, previous results will
+                                  be considered to skip re-validating AIPs for
+                                  this run.  This allows for lightweight
+                                  resume / retry functionality for a given
+                                  run.  [required]
+  -r, --retry-failed              Retry validation of AIPs if found in pre-
+                                  existing results but had failed.
   -w, --max-workers INTEGER       Maximum number of concurrent validation
                                   workers.  This should not exceed the maximum
                                   concurrency for the deployed AWS Lambda
@@ -112,7 +117,10 @@ pipenv run cli --verbose validate --aip-uuid="c73d10a7-7cd2-406f-95b6-b12e8f2da6
 pipenv run cli --verbose validate --s3-uri="s3://my-bucket/c73d/10a7/7cd2/406f/95bf/b12e/8f2d/a646/my-amazing-aip-c73d10a7-7cd2-406f-95b6-b12e8f2da646"
 
 # bulk validate against a list of AIPs in a CSV
-pipenv run cli --verbose bulk-validate --input-csv-filepath="output/bulk-uuids.csv"
+pipenv run cli --verbose bulk-validate --input-csv-filepath="output/bulk-uuids.csv" --output-csv-filepath="output/bulk-uuids-output.csv"
+
+# bulk validate against pre-existing file and retry failures
+pipenv run cli --verbose bulk-validate -i output/all-aips-2025-05-02.csv -o output/all-aips-2025-05-02.csv --retry-failed
 ```
 
 

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -148,15 +148,8 @@ def validate(ctx: click.Context, aip_uuid: str, s3_uri: str, *, details: bool) -
 @click.option(
     "--output-csv-filepath",
     "-o",
-    required=False,
+    required=True,
     help="Filepath of CSV for validation results.",
-)
-@click.option(
-    "--details",
-    "-d",
-    required=False,
-    is_flag=True,
-    help="Return full AIP validation details as JSON to stdout instead of 'OK'.",
 )
 @click.option(
     "--max-workers",
@@ -175,7 +168,6 @@ def bulk_validate(
     input_csv_filepath: str,
     output_csv_filepath: str,
     *,
-    details: bool,
     max_workers: int,
 ) -> None:
     """Bulk validate AIPs stored in S3 via the AIP UUID or S3 URI."""
@@ -245,9 +237,6 @@ def bulk_validate(
     valid_count = results_df["valid"].sum()
     total_count = len(results_df)
     click.echo(f"Validation complete: {valid_count}/{total_count} AIPs valid")
-
-    if details:
-        click.echo(results_df.to_json(orient="records", indent=2))
 
     if output_csv_filepath:
         results_df.to_csv(output_csv_filepath, index=False)

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -348,8 +348,9 @@ def validate_aip_bulk_worker(
 
         with results_lock:
             results_df.loc[row_index] = {  # type: ignore[call-overload]
-                "aip_uuid": row.aip_uuid,
-                "aip_s3_uri": result.get("s3_uri"),
+                "bucket": result.get("bucket"),
+                "aip_uuid": result.get("aip_uuid"),
+                "aip_s3_uri": result.get("aip_s3_uri"),
                 "valid": bool(result.get("valid", False)),
                 "error": result.get("error"),
                 "error_details": (

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -340,14 +340,6 @@ def validate_aip_bulk_worker(
     aip_uuid = row.get("aip_uuid")
     s3_uri = row.get("aip_s3_uri")
 
-    # ensure either AIP UUID or S3 URI present for row
-    if not (aip_uuid or s3_uri):
-        error_msg = "Row must have either aip_uuid or aip_s3_uri"
-        logger.error(error_msg)
-        with results_lock:
-            results_df.loc[row_index, "error"] = error_msg
-        return
-
     # attempt validation and update a results dataframe
     try:
         result = validate_aip_via_lambda(

--- a/lambdas/cli.py
+++ b/lambdas/cli.py
@@ -153,9 +153,9 @@ def validate(ctx: click.Context, aip_uuid: str, s3_uri: str, *, details: bool) -
     "-o",
     required=True,
     help=(
-        "Filepath of CSV for validation results.  If file already exists, previous "
-        "results will be considered to skip re-validating AIPs for this run.  This "
-        "allows for lightweight resume / retry functionality for a given run."
+        "Filepath of CSV for validation results.  If a file already exists, the previous "
+        "results will be used to skip re-validating AIPs for this run, allowing for "
+        "lightweight resume / retry functionality."
     ),
 )
 @click.option(
@@ -185,7 +185,7 @@ def bulk_validate(
     retry_failed: bool,
     max_workers: int,
 ) -> None:
-    """Bulk validate AIPs stored in S3 via the AIP UUID or S3 URI."""
+    """Bulk validate AIPs stored in S3 via a CSV of AIP UUIDs or S3 URIs."""
     try:
         input_df = pd.read_csv(input_csv_filepath).replace({np.nan: None})
     except FileNotFoundError as exc:

--- a/lambdas/utils/aws/s3_inventory.py
+++ b/lambdas/utils/aws/s3_inventory.py
@@ -242,6 +242,21 @@ class S3InventoryClient:
         self._aips_df = aips_df
         return aips_df
 
+    def get_aip_from_s3_uri(self, aip_s3_uri: str) -> pd.Series:
+        """Retrieve information about a specific AIP by its base S3 URI prefix."""
+        aips_df = self.get_aips_df()
+
+        if aip_s3_uri not in aips_df["aip_s3_uri"].to_numpy():
+            raise ValueError(f"AIP S3 URI '{aip_s3_uri}' not found in S3 Inventory data")
+        aip = aips_df.set_index("aip_s3_uri").loc[aip_s3_uri]
+        if isinstance(aip, pd.DataFrame):
+            raise TypeError(
+                f"Multiple entries found for AIP S3 URI '{aip_s3_uri}' "
+                "in S3 Inventory data"
+            )
+        aip.aip_s3_uri = aip_s3_uri
+        return aip
+
     def get_aip_from_uuid(self, aip_uuid: str) -> pd.Series:
         """Retrieve information about a specific AIP by its UUID."""
         aips_df = self.get_aips_df()
@@ -251,9 +266,9 @@ class S3InventoryClient:
         aip = aips_df.set_index("aip_uuid").loc[aip_uuid]
         if isinstance(aip, pd.DataFrame):
             raise TypeError(
-                f"Multiple entries found for AIP UUID '{aip_uuid}'in S3 Inventory data "
+                f"Multiple entries found for AIP UUID '{aip_uuid}'in S3 Inventory data"
             )
-
+        aip.aip_uuid = aip_uuid
         return aip
 
     def get_aip_inventory(

--- a/lambdas/validator.py
+++ b/lambdas/validator.py
@@ -170,6 +170,6 @@ def validate(payload: InputPayload) -> dict:
         )
 
     result = aip.validate(num_workers=payload.num_workers)
-    logger.info(f"AIP '{result.s3_uri}' is valid: {result.valid}")
+    logger.info(f"AIP '{result.aip_s3_uri}' is valid: {result.valid}")
 
     return generate_result_response(result.to_dict(exclude=["manifest"]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from lambdas.aip import AIP
+
 
 @pytest.fixture(autouse=True)
 def _test_env(monkeypatch, request):
@@ -117,3 +119,8 @@ def mock_checksums():
             # Set return values to match expected manifest checksums
             mock_decode.side_effect = ["abcdef1234567890", "fedcba0987654321"]
             yield mock_get, mock_decode
+
+
+@pytest.fixture
+def aip():
+    return AIP("abc123", "s3://bucket/aip/")

--- a/tests/fixtures/cli/bulk-validation/existing_results.csv
+++ b/tests/fixtures/cli/bulk-validation/existing_results.csv
@@ -1,0 +1,4 @@
+aip_uuid,aip_s3_uri,valid,error,error_details,elapsed
+test-uuid-1,s3://my-bucket/aips/test-uuid-1,False,Could not find 'manifest-sha256.txt' for AIP.,"{""type"": ""manifest_not_found"", ""s3_uri"": ""s3://my-bucket/aips/test-uuid-1/manifest-sha256.txt"", ""error_code"": ""NoSuchKey""}",0.26
+test-uuid-2,s3://my-bucket/aips/test-uuid-2,True,,,2.56
+test-uuid-3,s3://my-bucket/aips/test-uuid-3,True,,,2.56

--- a/tests/fixtures/cli/bulk-validation/input_with_existing_results.csv
+++ b/tests/fixtures/cli/bulk-validation/input_with_existing_results.csv
@@ -1,0 +1,5 @@
+aip_uuid
+test-uuid-1
+test-uuid-2
+test-uuid-3
+test-uuid-4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# ruff: noqa: D205, D209
+# ruff: noqa: D205, D209, PLR2004
 
 import json
 import shutil
@@ -213,7 +213,7 @@ class TestBulkValidateCommand:
 
         # two rows written despite other threads failing
         output_df = pd.read_csv(output_csv)
-        assert len(output_df)
+        assert len(output_df) == 2
 
     def test_bulk_validate_existing_incrementally_writes_during_parallel_validation(
         self, tmp_path, mocker, reraise
@@ -232,12 +232,12 @@ class TestBulkValidateCommand:
             # this use of 'reraise' (from 'pytest-reraise' library) is required for
             # bubbling up assertion failures that occur as part of a multithreaded process
             with reraise:
-                _row_idx, _row, _results_lock, _results_df, _output_csv_filepath = args
+                _row_index, _row, _results_lock, _results_df, _output_csv_filepath = args
                 with _results_lock:
                     output_csv_df = pd.read_csv(_output_csv_filepath)
 
                     # assert that CSV is growing relative to this AIP getting validated
-                    assert len(output_csv_df) == _row_idx + 1
+                    assert len(output_csv_df) == _row_index + 1
                     assert output_csv_df.iloc[-1].aip_uuid == _row.aip_uuid
 
                 return result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,7 +238,6 @@ class TestBulkValidateCommand:
 
                     # assert that CSV is growing relative to this AIP getting validated
                     assert len(output_csv_df) == _row_index + 1
-                    assert output_csv_df.iloc[-1].aip_uuid == _row.aip_uuid
 
                 return result
 
@@ -246,9 +245,9 @@ class TestBulkValidateCommand:
         mocker.patch(
             "lambdas.cli.validate_aip_via_lambda",
             return_value={
+                "aip_s3_uri": "s3://bucket/test",
                 "valid": True,
                 "elapsed": 1.5,
-                "s3_uri": "s3://bucket/test",
             },
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,7 @@
+# ruff: noqa: D205, D209
+
 import json
+import shutil
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
@@ -7,6 +10,7 @@ import pytest
 import requests
 from click.testing import CliRunner
 
+from lambdas import cli as cli_module
 from lambdas.cli import cli, validate_aip_via_lambda
 
 
@@ -101,34 +105,6 @@ class TestValidateCommand:
 
 
 class TestBulkValidateCommand:
-    def test_bulk_validate_success(self, tmp_path):
-        runner = CliRunner()
-        output_path = tmp_path / "output.csv"
-
-        with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
-            mock_validate.return_value = {
-                "valid": True,
-                "elapsed": 1.5,
-                "s3_uri": "s3://bucket/test",
-            }
-
-            result = runner.invoke(
-                cli,
-                [
-                    "bulk-validate",
-                    "-i",
-                    "tests/fixtures/cli/bulk-validation/single_uuid_input.csv",
-                    "-o",
-                    str(output_path),
-                ],
-            )
-            assert result.exit_code == 0
-            assert f"Results saved to {output_path}" in result.output
-
-            output_data = pd.read_csv(output_path)
-            assert len(output_data) == 1
-            assert bool(output_data["valid"].iloc[0]) is True
-
     def test_bulk_validate_invalid_input_csv(self, tmp_path):
         runner = CliRunner()
         output_path = tmp_path / "output.csv"
@@ -146,6 +122,147 @@ class TestBulkValidateCommand:
         assert (
             "Input CSV must have 'aip_uuid' and/or 'aip_s3_uri' columns" in result.output
         )
+
+    @pytest.mark.parametrize(
+        ("retry_failed", "expected_skipped_count", "expected_skipped_uuids"),
+        [
+            # With retry flag - all AIPs skipped
+            (False, 3, ["test-uuid-1", "test-uuid-2", "test-uuid-3"]),
+            # Without retry flag - only previously successful AIPs skipped
+            (True, 2, ["test-uuid-2", "test-uuid-3"]),
+        ],
+    )
+    def test_bulk_validate_existing_results(
+        self,
+        tmp_path,
+        retry_failed,
+        expected_skipped_count,
+        expected_skipped_uuids,
+    ):
+        """Test bulk validation with existing results, with and without --retry-failed."""
+        previous_output_csv = str(tmp_path / "output.csv")
+        shutil.copy(
+            "tests/fixtures/cli/bulk-validation/existing_results.csv",
+            previous_output_csv,
+        )
+
+        runner = CliRunner()
+        with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
+            # validation results are arbitrary
+            mock_validate.return_value = {
+                "valid": True,
+                "elapsed": 1.5,
+                "s3_uri": "s3://bucket/test",
+            }
+
+            args = [
+                "--verbose",
+                "bulk-validate",
+                "-i",
+                "tests/fixtures/cli/bulk-validation/existing_results.csv",
+                "-o",
+                previous_output_csv,
+            ]
+            if retry_failed:
+                args.append("--retry-failed")
+
+            result = runner.invoke(cli, args)
+
+            assert (
+                f"Found {expected_skipped_count} already validated AIPs, will skip these."
+                in result.output
+            )
+            for uuid in expected_skipped_uuids:
+                assert f"AIP '{uuid}' already validated, skipping." in result.output
+
+    def test_bulk_validate_incremental_writes_during_thread_failures(
+        self,
+        tmp_path,
+    ):
+        """Test that even when individual validation threads fail, content is still
+        getting written to output CSV."""
+        output_csv = str(tmp_path / "output.csv")
+
+        runner = CliRunner()
+        with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
+            mock_validate.side_effect = [
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "s3_uri": "s3://bucket/test",
+                },
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "s3_uri": "s3://bucket/test",
+                },
+                SystemExit(),  # mocks an AIP validation thread that quits unexpectedly
+                SystemExit(),  # mocks an AIP validation thread that quits unexpectedly
+            ]
+
+            args = [
+                "--verbose",
+                "bulk-validate",
+                "-i",
+                "tests/fixtures/cli/bulk-validation/input_with_existing_results.csv",
+                "-o",
+                output_csv,
+            ]
+
+            runner.invoke(cli, args)
+
+        # two rows written despite other threads failing
+        output_df = pd.read_csv(output_csv)
+        assert len(output_df)
+
+    def test_bulk_validate_existing_incrementally_writes_during_parallel_validation(
+        self, tmp_path, mocker, reraise
+    ):
+        """Test that as the threaded worker method validate_aip_bulk_worker runs, rows
+        are getting written to the output CSV.  This is important: if the CLI process
+        quits unexpectedly, we need to know that each threaded worker had already
+        written its content."""
+        output_csv = str(tmp_path / "output.csv")
+
+        original_worker = cli_module.validate_aip_bulk_worker
+
+        def wrapper_worker(*args, **kwargs):
+            result = original_worker(*args, **kwargs)
+
+            # this use of 'reraise' (from 'pytest-reraise' library) is required for
+            # bubbling up assertion failures that occur as part of a multithreaded process
+            with reraise:
+                _row_idx, _row, _results_lock, _results_df, _output_csv_filepath = args
+                with _results_lock:
+                    output_csv_df = pd.read_csv(_output_csv_filepath)
+
+                    # assert that CSV is growing relative to this AIP getting validated
+                    assert len(output_csv_df) == _row_idx + 1
+                    assert output_csv_df.iloc[-1].aip_uuid == _row.aip_uuid
+
+                return result
+
+        mocker.patch.object(cli_module, "validate_aip_bulk_worker", wrapper_worker)
+        mocker.patch(
+            "lambdas.cli.validate_aip_via_lambda",
+            return_value={
+                "valid": True,
+                "elapsed": 1.5,
+                "s3_uri": "s3://bucket/test",
+            },
+        )
+
+        runner = CliRunner()
+        args = [
+            "--verbose",
+            "bulk-validate",
+            "-i",
+            "tests/fixtures/cli/bulk-validation/input_with_existing_results.csv",
+            "-o",
+            output_csv,
+        ]
+
+        _result = runner.invoke(cli, args)
 
 
 class TestValidateAipViaLambda:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,11 +149,32 @@ class TestBulkValidateCommand:
         runner = CliRunner()
         with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
             # validation results are arbitrary
-            mock_validate.return_value = {
-                "valid": True,
-                "elapsed": 1.5,
-                "s3_uri": "s3://bucket/test",
-            }
+            mock_validate.side_effect = [
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "aip_uuid": "test-uuid-1",
+                    "aip_s3_uri": "s3://bucket/test",
+                },
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "aip_uuid": "test-uuid-2",
+                    "aip_s3_uri": "s3://bucket/test",
+                },
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "aip_uuid": "test-uuid-3",
+                    "aip_s3_uri": "s3://bucket/test",
+                },
+                {
+                    "valid": True,
+                    "elapsed": 1.5,
+                    "aip_uuid": "test-uuid-4",
+                    "aip_s3_uri": "s3://bucket/test",
+                },
+            ]
 
             args = [
                 "--verbose",
@@ -173,7 +194,7 @@ class TestBulkValidateCommand:
                 in result.output
             )
             for uuid in expected_skipped_uuids:
-                assert f"AIP '{uuid}' already validated, skipping." in result.output
+                assert f"AIP UUID '{uuid}' already validated, skipping." in result.output
 
     def test_bulk_validate_incremental_writes_during_thread_failures(
         self,
@@ -209,7 +230,7 @@ class TestBulkValidateCommand:
                 output_csv,
             ]
 
-            runner.invoke(cli, args)
+            _result = runner.invoke(cli, args)
 
         # two rows written despite other threads failing
         output_df = pd.read_csv(output_csv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,27 +101,7 @@ class TestValidateCommand:
 
 
 class TestBulkValidateCommand:
-    def test_bulk_validate_success(self):
-        runner = CliRunner()
-        with patch("lambdas.cli.validate_aip_via_lambda") as mock_validate:
-            mock_validate.return_value = {
-                "valid": True,
-                "elapsed": 1.5,
-                "s3_uri": "s3://bucket/test",
-            }
-
-            result = runner.invoke(
-                cli,
-                [
-                    "bulk-validate",
-                    "-i",
-                    "tests/fixtures/cli/bulk-validation/valid_input.csv",
-                ],
-            )
-            assert result.exit_code == 0
-            assert "Validation complete: 2/2 AIPs valid" in result.output
-
-    def test_bulk_validate_with_output_csv(self, tmp_path):
+    def test_bulk_validate_success(self, tmp_path):
         runner = CliRunner()
         output_path = tmp_path / "output.csv"
 
@@ -149,14 +129,17 @@ class TestBulkValidateCommand:
             assert len(output_data) == 1
             assert bool(output_data["valid"].iloc[0]) is True
 
-    def test_bulk_validate_invalid_csv(self):
+    def test_bulk_validate_invalid_input_csv(self, tmp_path):
         runner = CliRunner()
+        output_path = tmp_path / "output.csv"
         result = runner.invoke(
             cli,
             [
                 "bulk-validate",
                 "-i",
                 "tests/fixtures/cli/bulk-validation/invalid_input.csv",
+                "-o",
+                output_path,
             ],
         )
         assert result.exit_code == 1

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -140,7 +140,9 @@ class TestLambdaHandler:
             "challenge_secret": "i-am-secret",
         }
         mock_result = ValidationResponse(
-            s3_uri="s3://bucket/aip",
+            bucket="bucket",
+            aip_uuid="abc123",
+            aip_s3_uri="s3://bucket/aip",
             valid=True,
             elapsed=1.5,
             manifest={"data/file1.txt": "abc123"},
@@ -155,7 +157,7 @@ class TestLambdaHandler:
         assert response["statusDescription"] == "200 OK"
         body = json.loads(response["body"])
         assert body["valid"] is True
-        assert body["s3_uri"] == "s3://bucket/aip"
+        assert body["aip_s3_uri"] == "s3://bucket/aip"
 
     def test_lambda_handler_success_with_uuid(self):
         event = {
@@ -163,7 +165,9 @@ class TestLambdaHandler:
             "challenge_secret": "i-am-secret",
         }
         mock_result = ValidationResponse(
-            s3_uri="s3://bucket/aip",
+            bucket="bucket",
+            aip_uuid="abc123",
+            aip_s3_uri="s3://bucket/aip",
             valid=True,
             elapsed=1.5,
             manifest={"data/file1.txt": "abc123"},
@@ -177,7 +181,7 @@ class TestLambdaHandler:
         assert response["statusCode"] == HTTPStatus.OK
         body = json.loads(response["body"])
         assert body["valid"] is True
-        assert body["s3_uri"] == "s3://bucket/aip"
+        assert body["aip_s3_uri"] == "s3://bucket/aip"
 
     def test_lambda_handler_ping_action(self):
         event = {


### PR DESCRIPTION
_NOTE: this PR depends on [PR 66](https://github.com/MITLibraries/s3-bagit-validator/pull/66) getting merged._

### Purpose and background context

This PR improves bulk validation by providing some lightweight resume / retry functionality.  This is driven by reading the `--output-csv-filepath`, if it exists, as a form of "previous results" to consider.

Example:
1. Run `bulk-validation` with `--input-csv-filepath=input.csv` and `--output-csv-filepath=results.csv`
  a.  `input.csv` has 100 AIPs to check
3. 100 AIPs were passed as input, but process fails at 75 AIPs validated, and of those 70 valid / 5 invalid
4. _Re-run_ `bulk-validation` and _re-passing_ `--input-csv-filepath=input.csv` and `--output-csv-filepath=results.csv` and now include `--retry-failed`
5. The previous results are read before starting:
  a. the 70 previously checked and valid AIPs will be skipped
  b. the 5 previously checked but invalid will be retried (because of `--retry-failed`)
  c. the other 25 AIPs that never got checked, will finally get checked

While a more sophisticated system could be constructed -- perhaps with a SQLite database for "runs" + dates -- this approach works for the use cases outlined by stakeholders.  The following could be a realistic "quarterly" check of AIPs:

```shell
pipenv run cli bulk-validate \
--input-csv-filepath="2025-q2-input.csv" \
--input-csv-filepath="2025-q2-results.csv" \
--retry-failed
```

If something goes wrong, re-running that exact command should pick up where it left off.  Running it again, after a fully complete run, will do nothing (all AIPs will be skipped).  This makes `bulk-validate` somewhat **idempotent**.

### How can a reviewer manually see the effects of these changes?

_NOTE: This builds on [PR 66](https://github.com/MITLibraries/s3-bagit-validator/pull/66) and uses SAM for local lambda testing._

1- Set AWS Dev `ArchivematicaManagers` credentials

2- Set the following for `tests/sam/env.json`:
```json
{
  "S3BagitValidatorFunction": {
    "S3_INVENTORY_LOCATIONS": "s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore1b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore2b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-aipstore3b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore4b,s3://cdps-dev-inventory-222053980223/inventory/cdps-storage-dev-222053980223-aipstore5b"
  }
}
```

_SAM commands from terminal # 1_

3- Just to be thorough, build SAM image:
```shell
make sam-build
```

4- Start SAM server
```shell
make sam-run
```

_CLI commands from terminal # 2_

5- Run `ping` command to ensure all is working:
```shell
pipenv run cli --verbose ping
```

6- First run, establishes output CSV.

Create the following file `output/ir-228-input.csv`:
```csv
aip_uuid
29d47878-a513-475a-bd1d-ffabd1026e24
4038b73e-a2e5-4a59-9f45-e31e95cc9977
4b064dbd-1492-4ff7-a853-ab28e9c2fc74
```

Then run the `bulk-validate`:
```shell
pipenv run cli bulk-validate -w 2 -i output/ir-228-input.csv -o output/ir-228-output.csv
```

7- **Manually** modify the CSV and delete the last row (likely AIP `4b064dbd-1492-4ff7-a853-ab28e9c2fc74`)

8- Re-run bulk validation, noting that only a single AIP was processed:
```shell
pipenv run cli bulk-validate -w 2 -i output/ir-228-input.csv -o output/ir-228-output.csv
```

Expected output:
```
2025-04-23 10:30:44,953 INFO lambdas.cli.bulk_validate(): Found 2 already validated AIPs, will skip these.
2025-04-23 10:30:44,956 INFO lambdas.cli.validate_aip_via_lambda(): Validating AIP: 4b064dbd-1492-4ff7-a853-ab28e9c2fc74
2025-04-23 10:30:53,796 INFO lambdas.cli.validate_aip_via_lambda(): AIP 4b064dbd-1492-4ff7-a853-ab28e9c2fc74, validation result: OK
2025-04-23 10:30:53,809 INFO lambdas.cli.bulk_validate(): Progress: 1/1 AIPs processed (100.0%)
Validation complete: 3/3 AIPs valid.  Results saved to 'output/ir-228-output.csv'
```

9- **Manually** update CSV and replace a single `valid=True` with `valid=False`

10- Rerun again, noting that the `--retry-failed` flag is triggering the re-validation of that AIP:
```shell
pipenv run cli bulk-validate -w 2 -i output/ir-228-input.csv -o output/ir-228-output.csv --retry-failed
```

Should be functionally similar output to test above where AIP was deleted from output.

### Includes new or updated dependencies?
YES: `pytest-reraise`

This was a new library to me!  See [usage here](https://github.com/MITLibraries/s3-bagit-validator/pull/69/commits/1eab71121f6934695952ffe7f0268f20830f3c45#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR234).  This is testing that as parallel threads write to the CSV, it is growing row-by-row.  The difficulty of testing here is that normal `assert ...` statements are swallowed up because they are part of threaded calls.  Using `with reraise:...`, which is a fixture provided by this library, correctly bubbles up failures.  _Very_ handy for testing of multithreaded code.

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IR-228

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes