### PR TITLE
IR 206 subtasks - IR 231 and IR 232

### DIFF
--- a/lambdas/aip.py
+++ b/lambdas/aip.py
@@ -243,18 +243,18 @@ class AIP:
         if missing_in_aip:
             missing_files = list(missing_in_aip)
             raise AIPValidationError(
-                "Files found in manifest but missing from AIP",
+                "File(s) missing from AIP that are present in manifest",
                 error_details={
-                    "type": "files_missing_in_aip",
+                    "type": "files_missing_from_aip",
                     "missing_files": missing_files,
                 },
             )
         if missing_in_manifest:
             missing_files = list(missing_in_manifest)
             raise AIPValidationError(
-                "Files found in AIP but missing from manifest",
+                "Unexpected file(s) in AIP that are not present in manifest",
                 error_details={
-                    "type": "files_missing_in_manifest",
+                    "type": "unexpected_files_in_aip",
                     "missing_files": missing_files,
                 },
             )

--- a/tests/test_aip.py
+++ b/tests/test_aip.py
@@ -192,7 +192,8 @@ class TestAIP:
         with pytest.raises(AIPValidationError) as exc:
             aip._check_aip_files_match_manifest()
 
-        assert "Files found in manifest but missing from AIP" in str(exc.value)
+        assert "File(s) missing from AIP" in str(exc.value)
+        assert exc.value.error_details["type"] == "files_missing_from_aip"
 
     def test_check_aip_files_match_manifest_extra_files(
         self, mock_aip_folder, mock_manifest_data, aip
@@ -210,7 +211,8 @@ class TestAIP:
         with pytest.raises(AIPValidationError) as exc:
             aip._check_aip_files_match_manifest()
 
-        assert "Files found in AIP but missing from manifest" in str(exc.value)
+        assert "Unexpected file(s) in AIP" in str(exc.value)
+        assert exc.value.error_details["type"] == "unexpected_files_in_aip"
 
     def test_check_checksums_mismatch(self, aip):
         aip.manifest_df = pd.DataFrame(


### PR DESCRIPTION
_NOTE: this PR builds on [PR 66](https://github.com/MITLibraries/s3-bagit-validator/pull/66) and [PR 69](https://github.com/MITLibraries/s3-bagit-validator/pull/69)._

### Purpose and background context

This PR makes two primary updates based on findings from testing in [IR-206](https://mitlibraries.atlassian.net/browse/IR-206):

1. [IR-231](https://mitlibraries.atlassian.net/browse/IR-231): update terminology used for error reporting
2. [IR-232](https://mitlibraries.atlassian.net/browse/IR-232): improve SQL query that identifies valid AIPs in S3 Inventory data

This PR also includes a commit to update `pipenv check` command as per [outlined in this confluence doc](https://mitlibraries.atlassian.net/wiki/spaces/~712020891b98ee715c482a8101f080ef16e887/blog/2025/04/24/4562747397/pipenv+2025.0.1+and+check+safety+vulnerability+scanning#Temporary-Workaround).

### How can a reviewer manually see the effects of these changes?

#### IR-231, terminology

Not a lot to test here, can see the changes in language from code diff.  The following is a screenshot shared with testers that met their requirements:

<img width="1012" alt="Screenshot 2025-04-24 at 9 44 10 AM" src="https://github.com/user-attachments/assets/8690e19d-edc2-40ea-9071-1a5a65ed2d44" />

#### IR-232, updated AIP finding from Inventory

Specific to the AIP UUID that prompted this work, the following reveals that now this AIP UUID cannot even load an `AIP` class instance because it's not found as an "AIP" in the Inventory data.

1- Set AWS **Stage** `ArchivematicaManagers` env vars

2- Set env vars:
```shell
WORKSPACE=stage
SENTRY_DSN=None
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,pyathena
S3_INVENTORY_LOCATIONS=s3://cdps-stage-inventory-840055183494/inventory/cdps-storage-stage-aipstore1b,s3://cdps-stage-inventory-840055183494/inventory/cdps-storage-stage-aipstore2b,s3://cdps-stage-inventory-840055183494/inventory/cdps-storage-stage-aipstore3b,s3://cdps-stage-inventory-840055183494/inventory/cdps-storage-stage-840055183494-aipstore4b,s3://cdps-stage-inventory-840055183494/inventory/cdps-storage-stage-840055183494-aipstore5b
```

3- Start python shell
```shell
pipenv run ipython
```

4- Attempt to load AIP, which formerly worked, and note that an exception is thrown indicating the AIP cannot be found in Inventory data:

```python
from lambdas.validator import AIP
aip = AIP.from_uuid('573a39be-a49d-4281-bd8f-b33952863447')
# ValueError: AIP UUID '573a39be-a49d-4281-bd8f-b33952863447' not found in S3 Inventory data or not associated with a valid Bagit AIP
```

Note the updated error language of `"...or not associated with a valid Bagit AIP"`.  This is indicates that while perhaps the UUID shows up _somewhere_ in S3 Inventory data, we have determined it's not a Bagit AIP structure.

### Includes new or updated dependencies?
NO*: an asterisk, because `safety` is installed during build but only temporarily; the Pipfile and Pipfile.lock are not modified

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- Include links to Jira Software and/or Jira Service Management tickets here.

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

[IR-206]: https://mitlibraries.atlassian.net/browse/IR-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IR-231]: https://mitlibraries.atlassian.net/browse/IR-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IR-232]: https://mitlibraries.atlassian.net/browse/IR-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ